### PR TITLE
Harden cipher/poToken pipeline: races, leaks, clock skew, main-thread IO

### DIFF
--- a/library/src/main/kotlin/com/zemer/cipher/CipherWebView.kt
+++ b/library/src/main/kotlin/com/zemer/cipher/CipherWebView.kt
@@ -34,10 +34,35 @@ class CipherWebView private constructor(
     // carry a per-request id, echoed back by the JS bridge: a late result from a cancelled/
     // abandoned request must never resume the NEXT request's continuation with the wrong value.
     private var initContinuation: Continuation<CipherWebView>? = initContinuation
-    private var sigContinuation: Continuation<String>? = null
-    private var sigRequestId = 0
-    private var nContinuation: Continuation<String>? = null
-    private var nRequestId = 0
+    private val sigSlot = RequestSlot<String>()
+    private val nSlot = RequestSlot<String>()
+
+    /**
+     * Single-shot continuation slot with an id-checked take. arm() returns the request id the
+     * JS call must echo back; takeIfCurrent(id) ignores late callbacks from superseded
+     * requests (the stale-result guard); takeAny() is for renderer-gone/timeout paths, which
+     * must clear whatever is pending. Synchronized because JS-bridge callbacks arrive on a
+     * WebView-internal thread while onRenderProcessGone/timeouts run on the main thread.
+     * The distinct method names are deliberate: same-name overloads made dropping the id a
+     * silent, compile-clean way to reintroduce the race.
+     */
+    private class RequestSlot<T> {
+        private var continuation: Continuation<T>? = null
+        private var requestId = 0
+
+        @Synchronized
+        fun arm(cont: Continuation<T>): Int {
+            continuation = cont
+            return ++requestId
+        }
+
+        @Synchronized
+        fun takeIfCurrent(id: Int): Continuation<T>? =
+            if (id == requestId) continuation.also { continuation = null } else null
+
+        @Synchronized
+        fun takeAny(): Continuation<T>? = continuation.also { continuation = null }
+    }
 
     /**
      * Set once the WebView's renderer process has died (or an evaluate timed out, which on a
@@ -132,46 +157,16 @@ class CipherWebView private constructor(
         isDead = true
         val e = CipherRendererGoneException(reason)
         takeInitContinuation()?.resumeSafely { it.resumeWithException(e) }
-        takeSigContinuation()?.resumeSafely { it.resumeWithException(e) }
-        takeNContinuation()?.resumeSafely { it.resumeWithException(e) }
+        sigSlot.takeAny()?.resumeSafely { it.resumeWithException(e) }
+        nSlot.takeAny()?.resumeSafely { it.resumeWithException(e) }
         destroyWebView()
     }
 
-    // Single-shot takes — synchronized because JS-bridge callbacks arrive on a WebView-internal
+    // Single-shot take — synchronized because JS-bridge callbacks arrive on a WebView-internal
     // thread while onRenderProcessGone/timeouts run on the main thread.
     @Synchronized
     private fun takeInitContinuation(): Continuation<CipherWebView>? =
         initContinuation.also { initContinuation = null }
-
-    @Synchronized
-    private fun armSigContinuation(cont: Continuation<String>): Int {
-        sigContinuation = cont
-        return ++sigRequestId
-    }
-
-    @Synchronized
-    private fun armNContinuation(cont: Continuation<String>): Int {
-        nContinuation = cont
-        return ++nRequestId
-    }
-
-    /** Id-checked take: a late callback from a superseded request gets null and is ignored. */
-    @Synchronized
-    private fun takeSigContinuation(requestId: Int): Continuation<String>? =
-        if (requestId == sigRequestId) sigContinuation.also { sigContinuation = null } else null
-
-    @Synchronized
-    private fun takeNContinuation(requestId: Int): Continuation<String>? =
-        if (requestId == nRequestId) nContinuation.also { nContinuation = null } else null
-
-    // Unconditional takes for renderer-gone/timeout paths, which must clear whatever is pending.
-    @Synchronized
-    private fun takeSigContinuation(): Continuation<String>? =
-        sigContinuation.also { sigContinuation = null }
-
-    @Synchronized
-    private fun takeNContinuation(): Continuation<String>? =
-        nContinuation.also { nContinuation = null }
 
     private inline fun <T> T.resumeSafely(block: (T) -> Unit) {
         // A continuation cancelled by withTimeout may already be completed; never let that
@@ -451,7 +446,7 @@ function discoverAndInit() {
             withTimeout(EVAL_TIMEOUT_MS) {
                 withContext(Dispatchers.Main) {
                     suspendCancellableCoroutine { cont ->
-                        val requestId = armSigContinuation(cont)
+                        val requestId = sigSlot.arm(cont)
                         val constArgJs = if (sigInfo.constantArg != null) "${sigInfo.constantArg}" else "null"
                         val jsCall = "deobfuscateSig('${sigInfo.name}', $constArgJs, '${escapeJsString(obfuscatedSig)}', $requestId)"
                         Timber.tag(TAG).d("Evaluating JS: ${jsCall.take(100)}...")
@@ -472,14 +467,14 @@ function discoverAndInit() {
         Timber.tag(TAG).d("========== SIGNATURE RESULT ==========")
         Timber.tag(TAG).d("Result length: ${result.length} (requestId=$requestId)")
         Timber.tag(TAG).d("Result preview: ${result.take(50)}...")
-        takeSigContinuation(requestId)?.resumeSafely { it.resume(result) }
+        sigSlot.takeIfCurrent(requestId)?.resumeSafely { it.resume(result) }
     }
 
     @JavascriptInterface
     fun onSigError(requestId: Int, error: String) {
         Timber.tag(TAG).e("========== SIGNATURE ERROR ==========")
         Timber.tag(TAG).e("Error: $error (requestId=$requestId)")
-        takeSigContinuation(requestId)?.resumeSafely {
+        sigSlot.takeIfCurrent(requestId)?.resumeSafely {
             it.resumeWithException(CipherException("Sig deobfuscation failed: $error"))
         }
     }
@@ -500,7 +495,7 @@ function discoverAndInit() {
             withTimeout(EVAL_TIMEOUT_MS) {
                 withContext(Dispatchers.Main) {
                     suspendCancellableCoroutine { cont ->
-                        val requestId = armNContinuation(cont)
+                        val requestId = nSlot.arm(cont)
                         val jsCall = "transformN('${escapeJsString(nValue)}', $requestId)"
                         Timber.tag(TAG).d("Evaluating JS: $jsCall")
                         webView.evaluateJavascript(jsCall, null)
@@ -518,14 +513,14 @@ function discoverAndInit() {
         Timber.tag(TAG).d("========== N-TRANSFORM RESULT ==========")
         Timber.tag(TAG).d("Result: $result (requestId=$requestId)")
         Timber.tag(TAG).d("Result length: ${result.length}")
-        takeNContinuation(requestId)?.resumeSafely { it.resume(result) }
+        nSlot.takeIfCurrent(requestId)?.resumeSafely { it.resume(result) }
     }
 
     @JavascriptInterface
     fun onNError(requestId: Int, error: String) {
         Timber.tag(TAG).e("========== N-TRANSFORM ERROR ==========")
         Timber.tag(TAG).e("Error: $error (requestId=$requestId)")
-        takeNContinuation(requestId)?.resumeSafely {
+        nSlot.takeIfCurrent(requestId)?.resumeSafely {
             it.resumeWithException(CipherException("N-transform failed: $error"))
         }
     }
@@ -539,8 +534,8 @@ function discoverAndInit() {
     /** Timeout path: mark this instance dead, clear pending slots, throw renderer-gone. */
     private fun failAsRendererGone(reason: String): Nothing {
         isDead = true
-        takeSigContinuation()
-        takeNContinuation()
+        sigSlot.takeAny()
+        nSlot.takeAny()
         throw CipherRendererGoneException(reason)
     }
 
@@ -718,14 +713,11 @@ function discoverAndInit() {
                 Timber.tag(TAG).e("CipherWebView init timed out after ${CREATE_TIMEOUT_MS}ms — treating renderer as gone")
                 destroyQuietly(created)
                 throw CipherRendererGoneException("CipherWebView init timed out after ${CREATE_TIMEOUT_MS}ms")
-            } catch (e: CancellationException) {
-                // Caller cancelled — don't leak the half-initialized WebView.
-                destroyQuietly(created)
-                throw e
             } catch (e: Exception) {
-                // Init failed via an error resume (e.g. onPlayerJsError -> CipherException):
-                // destroy the half-initialized WebView too, or every failed create() leaks a
-                // live renderer process that the retry path then multiplies.
+                // Covers both caller cancellation (CancellationException is rethrown, never
+                // swallowed) and init failure via an error resume (e.g. onPlayerJsError ->
+                // CipherException): destroy the half-initialized WebView either way, or every
+                // failed create() leaks a live renderer that the retry path then multiplies.
                 destroyQuietly(created)
                 throw e
             }

--- a/library/src/main/kotlin/com/zemer/cipher/CipherWebView.kt
+++ b/library/src/main/kotlin/com/zemer/cipher/CipherWebView.kt
@@ -22,7 +22,6 @@ import kotlin.coroutines.resumeWithException
 
 class CipherWebView private constructor(
     context: Context,
-    private val playerJs: String,
     private val sigInfo: FunctionNameExtractor.SigFunctionInfo?,
     private val nFuncInfo: FunctionNameExtractor.NFunctionInfo?,
     initContinuation: Continuation<CipherWebView>,
@@ -31,10 +30,14 @@ class CipherWebView private constructor(
 
     // Single-shot continuation slots. All resumes go through takeAndNull-style helpers so a late
     // or duplicate JS-bridge callback (or a renderer-gone racing a normal resume) can never
-    // double-resume and crash inside a @JavascriptInterface method.
+    // double-resume and crash inside a @JavascriptInterface method. The sig/n slots additionally
+    // carry a per-request id, echoed back by the JS bridge: a late result from a cancelled/
+    // abandoned request must never resume the NEXT request's continuation with the wrong value.
     private var initContinuation: Continuation<CipherWebView>? = initContinuation
     private var sigContinuation: Continuation<String>? = null
+    private var sigRequestId = 0
     private var nContinuation: Continuation<String>? = null
+    private var nRequestId = 0
 
     /**
      * Set once the WebView's renderer process has died (or an evaluate timed out, which on a
@@ -141,6 +144,28 @@ class CipherWebView private constructor(
         initContinuation.also { initContinuation = null }
 
     @Synchronized
+    private fun armSigContinuation(cont: Continuation<String>): Int {
+        sigContinuation = cont
+        return ++sigRequestId
+    }
+
+    @Synchronized
+    private fun armNContinuation(cont: Continuation<String>): Int {
+        nContinuation = cont
+        return ++nRequestId
+    }
+
+    /** Id-checked take: a late callback from a superseded request gets null and is ignored. */
+    @Synchronized
+    private fun takeSigContinuation(requestId: Int): Continuation<String>? =
+        if (requestId == sigRequestId) sigContinuation.also { sigContinuation = null } else null
+
+    @Synchronized
+    private fun takeNContinuation(requestId: Int): Continuation<String>? =
+        if (requestId == nRequestId) nContinuation.also { nContinuation = null } else null
+
+    // Unconditional takes for renderer-gone/timeout paths, which must clear whatever is pending.
+    @Synchronized
     private fun takeSigContinuation(): Continuation<String>? =
         sigContinuation.also { sigContinuation = null }
 
@@ -154,98 +179,13 @@ class CipherWebView private constructor(
         runCatching { block(this) }
     }
 
-    private fun loadPlayerJsFromFile() {
-        val sigFuncName = sigInfo?.name
-        val nFuncName = nFuncInfo?.name
-        val nArrayIdx = nFuncInfo?.arrayIndex
-        val isHardcoded = sigInfo?.isHardcoded == true || nFuncInfo?.isHardcoded == true
-
-        Timber.tag(TAG).d("=== LOADING PLAYER.JS INTO WEBVIEW ===")
-        Timber.tag(TAG).d("Player.js size: ${playerJs.length} chars")
-        Timber.tag(TAG).d("Export mode: ${if (isHardcoded) "HARDCODED" else "EXTRACTED"}")
-        Timber.tag(TAG).d("Sig function: $sigFuncName (constantArg=${sigInfo?.constantArg})")
-        Timber.tag(TAG).d("N function: $nFuncName (arrayIdx=$nArrayIdx)")
-
-        usingHardcodedMode = isHardcoded
-
-        val exports = buildList {
-            val sigJsExpr = sigInfo?.jsExpression
-            if (sigJsExpr != null) {
-                // Expression-based sig decipher (VM-dispatch players like 9c249f6f).
-                // INPUT is replaced with the sig argument.
-                val expr = sigJsExpr.replace("INPUT", "sig")
-                Timber.tag(TAG).d("Sig: expression-based export: $expr")
-                add("window._cipherSigFunc = function(sig) { try { return $expr; } catch(e) { return null; } };")
-            } else if (sigFuncName != null) {
-                val sigConstArgs = sigInfo?.constantArgs
-                val preprocessFunc = sigInfo?.preprocessFunc
-                val preprocessArgs = sigInfo?.preprocessArgs
-
-                if (!sigConstArgs.isNullOrEmpty() && preprocessFunc != null && !preprocessArgs.isNullOrEmpty()) {
-                    val mainArgsStr = sigConstArgs.joinToString(", ")
-                    val prepArgsStr = preprocessArgs.joinToString(", ")
-                    Timber.tag(TAG).d("Sig function needs full wrapper:")
-                    Timber.tag(TAG).d("  $sigFuncName($mainArgsStr, $preprocessFunc($prepArgsStr, sig))")
-                    add("window._cipherSigFunc = function(sig) { return $sigFuncName($mainArgsStr, $preprocessFunc($prepArgsStr, sig)); };")
-                } else if (!sigConstArgs.isNullOrEmpty()) {
-                    val argsStr = sigConstArgs.joinToString(", ")
-                    Timber.tag(TAG).d("Sig function needs wrapper with constant args: $argsStr")
-                    add("window._cipherSigFunc = function(sig) { return $sigFuncName($argsStr, sig); };")
-                } else if (isHardcoded) {
-                    Timber.tag(TAG).d("Will export sig function $sigFuncName in hardcoded mode (legacy)")
-                    add("window._cipherSigFunc = typeof $sigFuncName !== 'undefined' ? $sigFuncName : null;")
-                } else {
-                    add("window._cipherSigFunc = typeof $sigFuncName !== 'undefined' ? $sigFuncName : null;")
-                }
-            }
-            val nJsExpr = nFuncInfo?.jsExpression
-            if (nJsExpr != null) {
-                // Expression-based n-transform (VM-dispatch players).
-                val expr = nJsExpr.replace("INPUT", "n")
-                Timber.tag(TAG).d("N: expression-based export: ${expr.take(80)}")
-                add("window._nTransformFunc = function(n) { try { return $expr; } catch(e) { return n; } };")
-            } else if (nFuncName != null) {
-                val nConstArgs = nFuncInfo?.constantArgs
-                if (!nConstArgs.isNullOrEmpty()) {
-                    val argsStr = nConstArgs.joinToString(", ")
-                    Timber.tag(TAG).d("N-function needs wrapper with constant args: $argsStr")
-                    add("window._nTransformFunc = function(n) { return $nFuncName($argsStr, n); };")
-                } else {
-                    val nExpr = if (nArrayIdx != null) {
-                        "$nFuncName[$nArrayIdx]"
-                    } else {
-                        nFuncName
-                    }
-                    add("window._nTransformFunc = typeof $nFuncName !== 'undefined' ? $nExpr : null;")
-                }
-            }
-        }
-
-        Timber.tag(TAG).d("Export statements: ${exports.size}")
-        exports.forEachIndexed { idx, stmt ->
-            Timber.tag(TAG).v("  Export[$idx]: ${stmt.take(80)}...")
-        }
-
-        val modifiedJs = if (exports.isNotEmpty()) {
-            val exportCode = "; " + exports.joinToString(" ")
-            val modified = playerJs.replace("})(_yt_player);", "$exportCode })(_yt_player);")
-            if (modified == playerJs) {
-                Timber.tag(TAG).w("Export injection point '})(_yt_player);' not found, appending exports")
-                playerJs + "\n" + exportCode
-            } else {
-                Timber.tag(TAG).d("Exports injected into IIFE closure")
-                modified
-            }
-        } else {
-            Timber.tag(TAG).w("No exports to inject")
-            playerJs
-        }
-
-        val cacheDir = File(webView.context.cacheDir, "cipher")
-        cacheDir.mkdirs()
-        val playerJsFile = File(cacheDir, "player.js")
-        playerJsFile.writeText(modifiedJs)
-        Timber.tag(TAG).d("Player.js written to cache: ${playerJsFile.absolutePath} (${modifiedJs.length} chars)")
+    /**
+     * Loads the already-prepared player.js (written by create() on an IO dispatcher via
+     * [buildModifiedPlayerJsImpl]) into the WebView. Only the cheap WebView work happens here
+     * on Main.
+     */
+    private fun loadPreparedPlayerJs(cacheDir: File) {
+        usingHardcodedMode = sigInfo?.isHardcoded == true || nFuncInfo?.isHardcoded == true
 
         val html = buildDiscoveryHtml()
         Timber.tag(TAG).d("Discovery HTML built (${html.length} chars)")
@@ -259,15 +199,15 @@ class CipherWebView private constructor(
 
     private fun buildDiscoveryHtml(): String = """<!DOCTYPE html>
 <html><head><script>
-function deobfuscateSig(funcName, constantArg, obfuscatedSig) {
-    CipherBridge.logDebug("deobfuscateSig called: funcName=" + funcName + ", constantArg=" + constantArg + ", sigLen=" + obfuscatedSig.length);
+function deobfuscateSig(funcName, constantArg, obfuscatedSig, reqId) {
+    CipherBridge.logDebug("deobfuscateSig called: funcName=" + funcName + ", constantArg=" + constantArg + ", sigLen=" + obfuscatedSig.length + ", reqId=" + reqId);
 
     try {
         var func = window._cipherSigFunc;
         CipherBridge.logDebug("window._cipherSigFunc type: " + typeof func + ", length: " + (func ? func.length : "N/A"));
 
         if (typeof func !== 'function') {
-            CipherBridge.onSigError("Sig func not found on window (type: " + typeof func + ")");
+            CipherBridge.onSigError(reqId, "Sig func not found on window (type: " + typeof func + ")");
             return;
         }
 
@@ -284,26 +224,26 @@ function deobfuscateSig(funcName, constantArg, obfuscatedSig) {
         }
 
         if (result === undefined || result === null) {
-            CipherBridge.onSigError("Function returned null/undefined");
+            CipherBridge.onSigError(reqId, "Function returned null/undefined");
             return;
         }
 
         CipherBridge.logDebug("Sig result type: " + typeof result + ", length: " + String(result).length);
-        CipherBridge.onSigResult(String(result));
+        CipherBridge.onSigResult(reqId, String(result));
     } catch (error) {
-        CipherBridge.onSigError(error + "\n" + (error.stack || ""));
+        CipherBridge.onSigError(reqId, error + "\n" + (error.stack || ""));
     }
 }
 
-function transformN(nValue) {
-    CipherBridge.logDebug("transformN called: nValue=" + nValue);
+function transformN(nValue, reqId) {
+    CipherBridge.logDebug("transformN called: nValue=" + nValue + ", reqId=" + reqId);
 
     try {
         var func = window._nTransformFunc;
         CipherBridge.logDebug("window._nTransformFunc type: " + typeof func);
 
         if (typeof func !== 'function') {
-            CipherBridge.onNError("N-transform func not available (type: " + typeof func + ")");
+            CipherBridge.onNError(reqId, "N-transform func not available (type: " + typeof func + ")");
             return;
         }
 
@@ -311,15 +251,15 @@ function transformN(nValue) {
         CipherBridge.logDebug("N-transform raw result: " + (result ? String(result).substring(0, 50) : "null/undefined"));
 
         if (result === undefined || result === null) {
-            CipherBridge.onNError("N-transform returned null/undefined");
+            CipherBridge.onNError(reqId, "N-transform returned null/undefined");
             return;
         }
 
         var resultStr = String(result);
         CipherBridge.logDebug("N-transform result: length=" + resultStr.length + ", value=" + resultStr.substring(0, 30));
-        CipherBridge.onNResult(resultStr);
+        CipherBridge.onNResult(reqId, resultStr);
     } catch (error) {
-        CipherBridge.onNError(error + "\n" + (error.stack || ""));
+        CipherBridge.onNError(reqId, error + "\n" + (error.stack || ""));
     }
 }
 
@@ -511,9 +451,9 @@ function discoverAndInit() {
             withTimeout(EVAL_TIMEOUT_MS) {
                 withContext(Dispatchers.Main) {
                     suspendCancellableCoroutine { cont ->
-                        sigContinuation = cont
+                        val requestId = armSigContinuation(cont)
                         val constArgJs = if (sigInfo.constantArg != null) "${sigInfo.constantArg}" else "null"
-                        val jsCall = "deobfuscateSig('${sigInfo.name}', $constArgJs, '${escapeJsString(obfuscatedSig)}')"
+                        val jsCall = "deobfuscateSig('${sigInfo.name}', $constArgJs, '${escapeJsString(obfuscatedSig)}', $requestId)"
                         Timber.tag(TAG).d("Evaluating JS: ${jsCall.take(100)}...")
                         webView.evaluateJavascript(jsCall, null)
                     }
@@ -528,18 +468,18 @@ function discoverAndInit() {
     }
 
     @JavascriptInterface
-    fun onSigResult(result: String) {
+    fun onSigResult(requestId: Int, result: String) {
         Timber.tag(TAG).d("========== SIGNATURE RESULT ==========")
-        Timber.tag(TAG).d("Result length: ${result.length}")
+        Timber.tag(TAG).d("Result length: ${result.length} (requestId=$requestId)")
         Timber.tag(TAG).d("Result preview: ${result.take(50)}...")
-        takeSigContinuation()?.resumeSafely { it.resume(result) }
+        takeSigContinuation(requestId)?.resumeSafely { it.resume(result) }
     }
 
     @JavascriptInterface
-    fun onSigError(error: String) {
+    fun onSigError(requestId: Int, error: String) {
         Timber.tag(TAG).e("========== SIGNATURE ERROR ==========")
-        Timber.tag(TAG).e("Error: $error")
-        takeSigContinuation()?.resumeSafely {
+        Timber.tag(TAG).e("Error: $error (requestId=$requestId)")
+        takeSigContinuation(requestId)?.resumeSafely {
             it.resumeWithException(CipherException("Sig deobfuscation failed: $error"))
         }
     }
@@ -560,8 +500,8 @@ function discoverAndInit() {
             withTimeout(EVAL_TIMEOUT_MS) {
                 withContext(Dispatchers.Main) {
                     suspendCancellableCoroutine { cont ->
-                        nContinuation = cont
-                        val jsCall = "transformN('${escapeJsString(nValue)}')"
+                        val requestId = armNContinuation(cont)
+                        val jsCall = "transformN('${escapeJsString(nValue)}', $requestId)"
                         Timber.tag(TAG).d("Evaluating JS: $jsCall")
                         webView.evaluateJavascript(jsCall, null)
                     }
@@ -574,18 +514,18 @@ function discoverAndInit() {
     }
 
     @JavascriptInterface
-    fun onNResult(result: String) {
+    fun onNResult(requestId: Int, result: String) {
         Timber.tag(TAG).d("========== N-TRANSFORM RESULT ==========")
-        Timber.tag(TAG).d("Result: $result")
+        Timber.tag(TAG).d("Result: $result (requestId=$requestId)")
         Timber.tag(TAG).d("Result length: ${result.length}")
-        takeNContinuation()?.resumeSafely { it.resume(result) }
+        takeNContinuation(requestId)?.resumeSafely { it.resume(result) }
     }
 
     @JavascriptInterface
-    fun onNError(error: String) {
+    fun onNError(requestId: Int, error: String) {
         Timber.tag(TAG).e("========== N-TRANSFORM ERROR ==========")
-        Timber.tag(TAG).e("Error: $error")
-        takeNContinuation()?.resumeSafely {
+        Timber.tag(TAG).e("Error: $error (requestId=$requestId)")
+        takeNContinuation(requestId)?.resumeSafely {
             it.resumeWithException(CipherException("N-transform failed: $error"))
         }
     }
@@ -645,6 +585,101 @@ function discoverAndInit() {
         // renderer died without onRenderProcessGone being delivered (old providers).
         private const val EVAL_TIMEOUT_MS = 15_000L
 
+        /**
+         * Builds the export-injected player.js. This scans and copies a ~2.8 MB string — it MUST run
+         * off the main thread (create() calls it on Dispatchers.IO before any WebView work), or every
+         * WebView (re)build would freeze the UI thread for the duration.
+         */
+        private fun buildModifiedPlayerJsImpl(
+            playerJs: String,
+            sigInfo: FunctionNameExtractor.SigFunctionInfo?,
+            nFuncInfo: FunctionNameExtractor.NFunctionInfo?,
+        ): String {
+            val sigFuncName = sigInfo?.name
+            val nFuncName = nFuncInfo?.name
+            val nArrayIdx = nFuncInfo?.arrayIndex
+            val isHardcoded = sigInfo?.isHardcoded == true || nFuncInfo?.isHardcoded == true
+
+            Timber.tag(TAG).d("=== PREPARING PLAYER.JS FOR WEBVIEW ===")
+            Timber.tag(TAG).d("Player.js size: ${playerJs.length} chars")
+            Timber.tag(TAG).d("Export mode: ${if (isHardcoded) "HARDCODED" else "EXTRACTED"}")
+            Timber.tag(TAG).d("Sig function: $sigFuncName (constantArg=${sigInfo?.constantArg})")
+            Timber.tag(TAG).d("N function: $nFuncName (arrayIdx=$nArrayIdx)")
+
+            val exports = buildList {
+                val sigJsExpr = sigInfo?.jsExpression
+                if (sigJsExpr != null) {
+                    // Expression-based sig decipher (VM-dispatch players like 9c249f6f).
+                    // INPUT is replaced with the sig argument.
+                    val expr = sigJsExpr.replace("INPUT", "sig")
+                    Timber.tag(TAG).d("Sig: expression-based export: $expr")
+                    add("window._cipherSigFunc = function(sig) { try { return $expr; } catch(e) { return null; } };")
+                } else if (sigFuncName != null) {
+                    val sigConstArgs = sigInfo?.constantArgs
+                    val preprocessFunc = sigInfo?.preprocessFunc
+                    val preprocessArgs = sigInfo?.preprocessArgs
+
+                    if (!sigConstArgs.isNullOrEmpty() && preprocessFunc != null && !preprocessArgs.isNullOrEmpty()) {
+                        val mainArgsStr = sigConstArgs.joinToString(", ")
+                        val prepArgsStr = preprocessArgs.joinToString(", ")
+                        Timber.tag(TAG).d("Sig function needs full wrapper:")
+                        Timber.tag(TAG).d("  $sigFuncName($mainArgsStr, $preprocessFunc($prepArgsStr, sig))")
+                        add("window._cipherSigFunc = function(sig) { return $sigFuncName($mainArgsStr, $preprocessFunc($prepArgsStr, sig)); };")
+                    } else if (!sigConstArgs.isNullOrEmpty()) {
+                        val argsStr = sigConstArgs.joinToString(", ")
+                        Timber.tag(TAG).d("Sig function needs wrapper with constant args: $argsStr")
+                        add("window._cipherSigFunc = function(sig) { return $sigFuncName($argsStr, sig); };")
+                    } else if (isHardcoded) {
+                        Timber.tag(TAG).d("Will export sig function $sigFuncName in hardcoded mode (legacy)")
+                        add("window._cipherSigFunc = typeof $sigFuncName !== 'undefined' ? $sigFuncName : null;")
+                    } else {
+                        add("window._cipherSigFunc = typeof $sigFuncName !== 'undefined' ? $sigFuncName : null;")
+                    }
+                }
+                val nJsExpr = nFuncInfo?.jsExpression
+                if (nJsExpr != null) {
+                    // Expression-based n-transform (VM-dispatch players).
+                    val expr = nJsExpr.replace("INPUT", "n")
+                    Timber.tag(TAG).d("N: expression-based export: ${expr.take(80)}")
+                    add("window._nTransformFunc = function(n) { try { return $expr; } catch(e) { return n; } };")
+                } else if (nFuncName != null) {
+                    val nConstArgs = nFuncInfo?.constantArgs
+                    if (!nConstArgs.isNullOrEmpty()) {
+                        val argsStr = nConstArgs.joinToString(", ")
+                        Timber.tag(TAG).d("N-function needs wrapper with constant args: $argsStr")
+                        add("window._nTransformFunc = function(n) { return $nFuncName($argsStr, n); };")
+                    } else {
+                        val nExpr = if (nArrayIdx != null) {
+                            "$nFuncName[$nArrayIdx]"
+                        } else {
+                            nFuncName
+                        }
+                        add("window._nTransformFunc = typeof $nFuncName !== 'undefined' ? $nExpr : null;")
+                    }
+                }
+            }
+
+            Timber.tag(TAG).d("Export statements: ${exports.size}")
+            exports.forEachIndexed { idx, stmt ->
+                Timber.tag(TAG).v("  Export[$idx]: ${stmt.take(80)}...")
+            }
+
+            return if (exports.isNotEmpty()) {
+                val exportCode = "; " + exports.joinToString(" ")
+                val modified = playerJs.replace("})(_yt_player);", "$exportCode })(_yt_player);")
+                if (modified == playerJs) {
+                    Timber.tag(TAG).w("Export injection point '})(_yt_player);' not found, appending exports")
+                    playerJs + "\n" + exportCode
+                } else {
+                    Timber.tag(TAG).d("Exports injected into IIFE closure")
+                    modified
+                }
+            } else {
+                Timber.tag(TAG).w("No exports to inject")
+                playerJs
+            }
+        }
+
         suspend fun create(
             context: Context,
             playerJs: String,
@@ -656,14 +691,26 @@ function discoverAndInit() {
             Timber.tag(TAG).d("sigInfo: $sigInfo")
             Timber.tag(TAG).d("nFuncInfo: $nFuncInfo")
 
+            // Heavy prep (multi-MB string transform + disk write) runs on IO; only WebView
+            // construction and the load call happen on the main thread below.
+            val cacheDir = withContext(Dispatchers.IO) {
+                val modifiedJs = buildModifiedPlayerJsImpl(playerJs, sigInfo, nFuncInfo)
+                val dir = File(context.cacheDir, "cipher")
+                dir.mkdirs()
+                val playerJsFile = File(dir, "player.js")
+                playerJsFile.writeText(modifiedJs)
+                Timber.tag(TAG).d("Player.js written to cache: ${playerJsFile.absolutePath} (${modifiedJs.length} chars)")
+                dir
+            }
+
             var created: CipherWebView? = null
             try {
                 return withTimeout(CREATE_TIMEOUT_MS) {
                     withContext(Dispatchers.Main) {
                         suspendCancellableCoroutine { cont ->
-                            val wv = CipherWebView(context, playerJs, sigInfo, nFuncInfo, cont)
+                            val wv = CipherWebView(context, sigInfo, nFuncInfo, cont)
                             created = wv
-                            wv.loadPlayerJsFromFile()
+                            wv.loadPreparedPlayerJs(cacheDir)
                         }
                     }
                 }
@@ -673,6 +720,12 @@ function discoverAndInit() {
                 throw CipherRendererGoneException("CipherWebView init timed out after ${CREATE_TIMEOUT_MS}ms")
             } catch (e: CancellationException) {
                 // Caller cancelled — don't leak the half-initialized WebView.
+                destroyQuietly(created)
+                throw e
+            } catch (e: Exception) {
+                // Init failed via an error resume (e.g. onPlayerJsError -> CipherException):
+                // destroy the half-initialized WebView too, or every failed create() leaks a
+                // live renderer process that the retry path then multiplies.
                 destroyQuietly(created)
                 throw e
             }

--- a/library/src/main/kotlin/com/zemer/cipher/FunctionNameExtractor.kt
+++ b/library/src/main/kotlin/com/zemer/cipher/FunctionNameExtractor.kt
@@ -43,6 +43,10 @@ object FunctionNameExtractor {
 
     private val Q_ARRAY_PATTERN = Regex("""var\s+Q\s*=\s*"[^"]+"\s*\.\s*split\s*\(\s*"\}"\s*\)""")
 
+    // See extractSignatureTimestamp for why these two are tried in different precedence tiers.
+    private val ANCHORED_STS_PATTERN = Regex("""signatureTimestamp['":\s]+(\d+)""")
+    private val LOOSE_STS_PATTERN = Regex("""sts['":\s]+(\d+)""")
+
     private val PLAYER_HASH_PATTERNS = listOf(
         Regex("""jsUrl['":\s]+[^"']*?/player/([a-f0-9]{8})/"""),
         Regex("""player_ias\.vflset/[^/]+/([a-f0-9]{8})/"""),
@@ -238,10 +242,18 @@ object FunctionNameExtractor {
     fun extractSignatureTimestamp(playerJs: String, knownHash: String? = null): Int? {
         Timber.tag(TAG).d("Extracting signatureTimestamp...")
 
-        // Validated config first — same precedence rationale as extractSigFunctionInfo: the
-        // patterns below are unanchored heuristics over ~2 MB of JS (`sts` especially can
-        // false-match), while a config entry is validated before it ships. A heuristic must
-        // never shadow a validated config.
+        // Precedence: (1) the anchored `signatureTimestamp` literal in the JS itself — it is
+        // the player's own embedded field and the source config sts values are copied from
+        // at authoring time, so it is immune to config typos, stale aliases, and bad remote
+        // pushes (configs' sts is NOT CDN-validated, unlike sig/n); (2) the config, for
+        // players lacking the literal; (3) the loose `sts` pattern, which can false-match
+        // anywhere in ~2 MB of JS and must never shadow the other two.
+        val anchored = ANCHORED_STS_PATTERN.find(playerJs)?.groupValues?.get(1)?.toIntOrNull()
+        if (anchored != null) {
+            Timber.tag(TAG).d("signatureTimestamp from player JS literal: $anchored")
+            return anchored
+        }
+
         val playerHash = knownHash ?: extractPlayerHash(playerJs)
         if (playerHash != null) {
             val config = getHardcodedConfig(playerHash)
@@ -251,21 +263,10 @@ object FunctionNameExtractor {
             }
         }
 
-        val patterns = listOf(
-            Regex("""signatureTimestamp['":\s]+(\d+)"""),
-            Regex("""sts['":\s]+(\d+)"""),
-            Regex(""""signatureTimestamp"\s*:\s*(\d+)""")
-        )
-
-        for ((index, pattern) in patterns.withIndex()) {
-            val match = pattern.find(playerJs)
-            if (match != null) {
-                val sts = match.groupValues[1].toIntOrNull()
-                if (sts != null) {
-                    Timber.tag(TAG).d("signatureTimestamp found via pattern $index: $sts")
-                    return sts
-                }
-            }
+        val loose = LOOSE_STS_PATTERN.find(playerJs)?.groupValues?.get(1)?.toIntOrNull()
+        if (loose != null) {
+            Timber.tag(TAG).d("signatureTimestamp via loose sts pattern: $loose")
+            return loose
         }
 
         Timber.tag(TAG).w("Could not extract signatureTimestamp")

--- a/library/src/main/kotlin/com/zemer/cipher/FunctionNameExtractor.kt
+++ b/library/src/main/kotlin/com/zemer/cipher/FunctionNameExtractor.kt
@@ -235,8 +235,21 @@ object FunctionNameExtractor {
         return null
     }
 
-    fun extractSignatureTimestamp(playerJs: String): Int? {
+    fun extractSignatureTimestamp(playerJs: String, knownHash: String? = null): Int? {
         Timber.tag(TAG).d("Extracting signatureTimestamp...")
+
+        // Validated config first — same precedence rationale as extractSigFunctionInfo: the
+        // patterns below are unanchored heuristics over ~2 MB of JS (`sts` especially can
+        // false-match), while a config entry is validated before it ships. A heuristic must
+        // never shadow a validated config.
+        val playerHash = knownHash ?: extractPlayerHash(playerJs)
+        if (playerHash != null) {
+            val config = getHardcodedConfig(playerHash)
+            if (config != null) {
+                Timber.tag(TAG).d("Using hardcoded signatureTimestamp: ${config.signatureTimestamp}")
+                return config.signatureTimestamp
+            }
+        }
 
         val patterns = listOf(
             Regex("""signatureTimestamp['":\s]+(\d+)"""),
@@ -252,15 +265,6 @@ object FunctionNameExtractor {
                     Timber.tag(TAG).d("signatureTimestamp found via pattern $index: $sts")
                     return sts
                 }
-            }
-        }
-
-        val playerHash = extractPlayerHash(playerJs)
-        if (playerHash != null) {
-            val config = getHardcodedConfig(playerHash)
-            if (config != null) {
-                Timber.tag(TAG).d("Using hardcoded signatureTimestamp: ${config.signatureTimestamp}")
-                return config.signatureTimestamp
             }
         }
 

--- a/library/src/main/kotlin/com/zemer/cipher/PlayerConfigStore.kt
+++ b/library/src/main/kotlin/com/zemer/cipher/PlayerConfigStore.kt
@@ -72,13 +72,20 @@ object PlayerConfigStore {
     // The two cooldown gates read DIFFERENT stamps on purpose (see above). Routed through these
     // functions — which forceRefresh / refreshAfterStreamRejection actually call — so a unit test
     // can prove neither path is gated by the other's cooldown without touching the network.
-    // The in-range check (not a plain `< COOLDOWN`) matters: these use wall-clock time, and a
-    // backward clock adjustment (NTP correction, manual change) makes the delta negative — a
-    // plain less-than would then hold the cooldown for the entire skew duration, wedging the
-    // self-heal paths exactly while playback is broken.
-    internal fun forcedCooldownActive(now: Long) = (now - lastForcedAttemptMs) in 0 until FORCE_REFRESH_COOLDOWN_MS
+    /**
+     * True iff [stampMs] lies within [windowMs] of [now]. The in-range check (not a plain
+     * `now - stamp < window`) matters: these are wall-clock stamps, and a backward clock
+     * adjustment (NTP correction, manual change) makes the delta negative — a plain
+     * less-than would then hold the window for the entire skew duration, wedging
+     * cooldowns/TTLs exactly while playback is broken. Every wall-clock window check in
+     * this module MUST go through this helper.
+     */
+    internal fun withinWindow(now: Long, stampMs: Long, windowMs: Long) =
+        (now - stampMs) in 0 until windowMs
 
-    internal fun rejectionCooldownActive(now: Long) = (now - lastRejectionAttemptMs) in 0 until FORCE_REFRESH_COOLDOWN_MS
+    internal fun forcedCooldownActive(now: Long) = withinWindow(now, lastForcedAttemptMs, FORCE_REFRESH_COOLDOWN_MS)
+
+    internal fun rejectionCooldownActive(now: Long) = withinWindow(now, lastRejectionAttemptMs, FORCE_REFRESH_COOLDOWN_MS)
 
     // Test-only: arm a cooldown stamp without invoking the network refresh paths.
     internal fun armForcedCooldownForTest(ms: Long) { lastForcedAttemptMs = ms }
@@ -227,12 +234,10 @@ object PlayerConfigStore {
 
     private suspend fun refreshIfStale() {
         val lastFetchMs = readMeta()?.second ?: 0L
-        // In-range check: lastFetchMs is persisted, so a future stamp (wall clock stepped back
-        // after the write) must count as stale, not fresh — otherwise the startup refresh stays
-        // wedged across restarts until real time catches up.
-        val age = System.currentTimeMillis() - lastFetchMs
-        if (age in 0 until REFRESH_TTL_MS) {
-            Timber.tag(TAG).d("Remote configs fresh (fetched $age ms ago)")
+        // lastFetchMs is persisted, so a future stamp (wall clock stepped back after the
+        // write) must count as stale, not fresh — withinWindow handles that.
+        if (withinWindow(System.currentTimeMillis(), lastFetchMs, REFRESH_TTL_MS)) {
+            Timber.tag(TAG).d("Remote configs fresh (fetched ${System.currentTimeMillis() - lastFetchMs} ms ago)")
             return
         }
         withContext(Dispatchers.IO) {
@@ -391,9 +396,14 @@ object PlayerConfigStore {
         val tmp = File(file.parentFile, "${file.name}.tmp")
         tmp.writeText(content)
         if (!tmp.renameTo(file)) {
-            // renameTo can fail on some filesystems — fall back to a direct write.
-            file.writeText(content)
-            tmp.delete()
+            // renameTo won't overwrite an existing target on some filesystems — retry after
+            // deleting it (two cheap metadata ops, still atomic) before the last-resort direct
+            // write, which is both non-atomic and a second full write of the content.
+            file.delete()
+            if (!tmp.renameTo(file)) {
+                file.writeText(content)
+                tmp.delete()
+            }
         }
     }
 }

--- a/library/src/main/kotlin/com/zemer/cipher/PlayerConfigStore.kt
+++ b/library/src/main/kotlin/com/zemer/cipher/PlayerConfigStore.kt
@@ -72,9 +72,13 @@ object PlayerConfigStore {
     // The two cooldown gates read DIFFERENT stamps on purpose (see above). Routed through these
     // functions — which forceRefresh / refreshAfterStreamRejection actually call — so a unit test
     // can prove neither path is gated by the other's cooldown without touching the network.
-    internal fun forcedCooldownActive(now: Long) = now - lastForcedAttemptMs < FORCE_REFRESH_COOLDOWN_MS
+    // The in-range check (not a plain `< COOLDOWN`) matters: these use wall-clock time, and a
+    // backward clock adjustment (NTP correction, manual change) makes the delta negative — a
+    // plain less-than would then hold the cooldown for the entire skew duration, wedging the
+    // self-heal paths exactly while playback is broken.
+    internal fun forcedCooldownActive(now: Long) = (now - lastForcedAttemptMs) in 0 until FORCE_REFRESH_COOLDOWN_MS
 
-    internal fun rejectionCooldownActive(now: Long) = now - lastRejectionAttemptMs < FORCE_REFRESH_COOLDOWN_MS
+    internal fun rejectionCooldownActive(now: Long) = (now - lastRejectionAttemptMs) in 0 until FORCE_REFRESH_COOLDOWN_MS
 
     // Test-only: arm a cooldown stamp without invoking the network refresh paths.
     internal fun armForcedCooldownForTest(ms: Long) { lastForcedAttemptMs = ms }
@@ -223,8 +227,12 @@ object PlayerConfigStore {
 
     private suspend fun refreshIfStale() {
         val lastFetchMs = readMeta()?.second ?: 0L
-        if (System.currentTimeMillis() - lastFetchMs < REFRESH_TTL_MS) {
-            Timber.tag(TAG).d("Remote configs fresh (fetched ${System.currentTimeMillis() - lastFetchMs} ms ago)")
+        // In-range check: lastFetchMs is persisted, so a future stamp (wall clock stepped back
+        // after the write) must count as stale, not fresh — otherwise the startup refresh stays
+        // wedged across restarts until real time catches up.
+        val age = System.currentTimeMillis() - lastFetchMs
+        if (age in 0 until REFRESH_TTL_MS) {
+            Timber.tag(TAG).d("Remote configs fresh (fetched $age ms ago)")
             return
         }
         withContext(Dispatchers.IO) {

--- a/library/src/main/kotlin/com/zemer/cipher/PlayerJsFetcher.kt
+++ b/library/src/main/kotlin/com/zemer/cipher/PlayerJsFetcher.kt
@@ -46,7 +46,7 @@ object PlayerJsFetcher {
                 if (cached != null) {
                     Timber.tag(TAG).d("Using cached player JS (hash=${cached.second})")
                     if (cachedSignatureTimestamp == null) {
-                        cachedSignatureTimestamp = FunctionNameExtractor.extractSignatureTimestamp(cached.first)
+                        cachedSignatureTimestamp = FunctionNameExtractor.extractSignatureTimestamp(cached.first, cached.second)
                         Timber.tag(TAG).d("STS from cached player: $cachedSignatureTimestamp")
                     }
                     return@withContext cached
@@ -71,7 +71,7 @@ object PlayerJsFetcher {
 
             // Cache the result
             writeToCache(hash, playerJs)
-            cachedSignatureTimestamp = FunctionNameExtractor.extractSignatureTimestamp(playerJs)
+            cachedSignatureTimestamp = FunctionNameExtractor.extractSignatureTimestamp(playerJs, hash)
             Timber.tag(TAG).d("STS from fresh player ($hash): $cachedSignatureTimestamp")
 
             Pair(playerJs, hash)
@@ -104,9 +104,12 @@ object PlayerJsFetcher {
             val hash = hashData[0]
             val timestamp = hashData[1].toLongOrNull() ?: return null
 
-            // Check TTL
-            if (System.currentTimeMillis() - timestamp > CACHE_TTL_MS) {
-                Timber.tag(TAG).d("Cache expired (hash=$hash)")
+            // Check TTL. In-range check: a future timestamp (wall clock stepped back after the
+            // write) must count as expired, not fresh — otherwise a stale player is served for
+            // the whole skew duration.
+            val age = System.currentTimeMillis() - timestamp
+            if (age !in 0..CACHE_TTL_MS) {
+                Timber.tag(TAG).d("Cache expired (hash=$hash, age=$age)")
                 return null
             }
 
@@ -129,8 +132,11 @@ object PlayerJsFetcher {
             // Clean old cache files
             cacheDir.listFiles()?.filter { it.name.startsWith("player_") }?.forEach { it.delete() }
 
-            getCacheFile(hash).writeText(playerJs)
-            getHashFile().writeText("$hash\n${System.currentTimeMillis()}")
+            // Atomic (temp + rename): a plain writeText truncates first, so process death during
+            // a same-hash force-refresh rewrite would leave a truncated player.js that
+            // readFromCache happily serves until the TTL expires.
+            PlayerConfigStore.writeAtomic(getCacheFile(hash), playerJs)
+            PlayerConfigStore.writeAtomic(getHashFile(), "$hash\n${System.currentTimeMillis()}")
         } catch (e: Exception) {
             Timber.tag(TAG).e(e, "Error writing cache: ${e.message}")
         }
@@ -142,13 +148,15 @@ object PlayerJsFetcher {
             .header("User-Agent", "Mozilla/5.0")
             .build()
 
-        val response = httpClient.newCall(request).execute()
-        if (!response.isSuccessful) {
-            Timber.tag(TAG).e("iframe_api HTTP ${response.code}")
-            return null
-        }
-
-        val body = response.body?.string() ?: return null
+        // .use{} so the response is closed on the error path too (an unread body would
+        // otherwise strand its connection).
+        val body = httpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                Timber.tag(TAG).e("iframe_api HTTP ${response.code}")
+                return null
+            }
+            response.body?.string()
+        } ?: return null
         val match = PLAYER_HASH_REGEX.find(body)
         return match?.groupValues?.get(1)
     }
@@ -160,12 +168,12 @@ object PlayerJsFetcher {
             .header("User-Agent", "Mozilla/5.0")
             .build()
 
-        val response = httpClient.newCall(request).execute()
-        if (!response.isSuccessful) {
-            Timber.tag(TAG).e("player JS download HTTP ${response.code}")
-            return null
+        return httpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                Timber.tag(TAG).e("player JS download HTTP ${response.code}")
+                return null
+            }
+            response.body?.string()
         }
-
-        return response.body?.string()
     }
 }

--- a/library/src/main/kotlin/com/zemer/cipher/PlayerJsFetcher.kt
+++ b/library/src/main/kotlin/com/zemer/cipher/PlayerJsFetcher.kt
@@ -29,6 +29,12 @@ object PlayerJsFetcher {
     // Regex to extract player hash from iframe_api response
     private val PLAYER_HASH_REGEX = Regex("""\\?/s\\?/player\\?/([a-zA-Z0-9_-]+)\\?/""")
 
+    // Serializes cache mutations: getPlayerJs has UNsynchronized concurrent callers (prewarm,
+    // signatureTimestamp() outside deobfuscateMutex, the app's EjsNTransformSolver), and an
+    // unlocked writeToCache purge racing another writer's writeAtomic tmp window would delete
+    // the tmp mid-write and silently degrade to a truncating non-atomic write.
+    private val cacheWriteLock = Any()
+
     private fun getCacheDir(): File = File(CipherDeobfuscator.appContext.filesDir, "cipher_cache")
 
     private fun getCacheFile(hash: String): File = File(getCacheDir(), "player_$hash.js")
@@ -82,14 +88,16 @@ object PlayerJsFetcher {
     }
 
     fun invalidateCache() {
-        try {
-            val cacheDir = getCacheDir()
-            if (cacheDir.exists()) {
-                cacheDir.listFiles()?.forEach { it.delete() }
+        synchronized(cacheWriteLock) {
+            try {
+                val cacheDir = getCacheDir()
+                if (cacheDir.exists()) {
+                    cacheDir.listFiles()?.forEach { it.delete() }
+                }
+                Timber.tag(TAG).d("Cache invalidated")
+            } catch (e: Exception) {
+                Timber.tag(TAG).e(e, "Failed to invalidate cache: ${e.message}")
             }
-            Timber.tag(TAG).d("Cache invalidated")
-        } catch (e: Exception) {
-            Timber.tag(TAG).e(e, "Failed to invalidate cache: ${e.message}")
         }
     }
 
@@ -104,12 +112,10 @@ object PlayerJsFetcher {
             val hash = hashData[0]
             val timestamp = hashData[1].toLongOrNull() ?: return null
 
-            // Check TTL. In-range check: a future timestamp (wall clock stepped back after the
-            // write) must count as expired, not fresh — otherwise a stale player is served for
-            // the whole skew duration.
-            val age = System.currentTimeMillis() - timestamp
-            if (age !in 0..CACHE_TTL_MS) {
-                Timber.tag(TAG).d("Cache expired (hash=$hash, age=$age)")
+            // Check TTL (withinWindow: a future timestamp from a backward clock step counts
+            // as expired, not fresh).
+            if (!PlayerConfigStore.withinWindow(System.currentTimeMillis(), timestamp, CACHE_TTL_MS)) {
+                Timber.tag(TAG).d("Cache expired (hash=$hash)")
                 return null
             }
 
@@ -127,18 +133,20 @@ object PlayerJsFetcher {
     }
 
     private fun writeToCache(hash: String, playerJs: String) {
-        try {
-            val cacheDir = getCacheDir()
-            // Clean old cache files
-            cacheDir.listFiles()?.filter { it.name.startsWith("player_") }?.forEach { it.delete() }
+        synchronized(cacheWriteLock) {
+            try {
+                val cacheDir = getCacheDir()
+                // Clean old cache files
+                cacheDir.listFiles()?.filter { it.name.startsWith("player_") }?.forEach { it.delete() }
 
-            // Atomic (temp + rename): a plain writeText truncates first, so process death during
-            // a same-hash force-refresh rewrite would leave a truncated player.js that
-            // readFromCache happily serves until the TTL expires.
-            PlayerConfigStore.writeAtomic(getCacheFile(hash), playerJs)
-            PlayerConfigStore.writeAtomic(getHashFile(), "$hash\n${System.currentTimeMillis()}")
-        } catch (e: Exception) {
-            Timber.tag(TAG).e(e, "Error writing cache: ${e.message}")
+                // Atomic (temp + rename): a plain writeText truncates first, so process death
+                // during a same-hash force-refresh rewrite would leave a truncated player.js
+                // that readFromCache happily serves until the TTL expires.
+                PlayerConfigStore.writeAtomic(getCacheFile(hash), playerJs)
+                PlayerConfigStore.writeAtomic(getHashFile(), "$hash\n${System.currentTimeMillis()}")
+            } catch (e: Exception) {
+                Timber.tag(TAG).e(e, "Error writing cache: ${e.message}")
+            }
         }
     }
 

--- a/library/src/main/kotlin/com/zemer/cipher/potoken/PoTokenGenerator.kt
+++ b/library/src/main/kotlin/com/zemer/cipher/potoken/PoTokenGenerator.kt
@@ -64,20 +64,36 @@ class PoTokenGenerator {
 
                 if (shouldRecreate) {
                     Timber.tag(TAG).d("Creating new PoTokenWebView (forceRecreate=$forceRecreate)")
-                    webPoTokenSessionId = sessionId
 
                     withContext(Dispatchers.Main) {
                         webPoTokenGenerator?.close()
                     }
 
-                    // create a new webPoTokenGenerator
-                    webPoTokenGenerator = PoTokenWebView.getNewPoTokenGenerator(CipherDeobfuscator.appContext)
+                    // Clear the committed state BEFORE the fallible steps below: if creation or
+                    // the session mint throws, the next call must compute shouldRecreate=true
+                    // instead of pairing the already-updated sessionId with a null/stale
+                    // sessionPot at the Triple below.
+                    webPoTokenGenerator = null
+                    webPoTokenSessionPot = null
+                    webPoTokenSessionId = null
+
+                    val newGenerator = PoTokenWebView.getNewPoTokenGenerator(CipherDeobfuscator.appContext)
 
                     // The session poToken (bound to visitorData) must be generated exactly once,
                     // before any per-video tokens. It is reused across videos and sent in the
                     // /player request.
-                    webPoTokenSessionPot = webPoTokenGenerator!!.generatePoToken(webPoTokenSessionId!!)
-                    Timber.tag(TAG).d("Session poToken generated for sessionId=${webPoTokenSessionId?.take(20)}...")
+                    val newSessionPot = try {
+                        newGenerator.generatePoToken(sessionId)
+                    } catch (t: Throwable) {
+                        // Don't leak the freshly created WebView (close() hops to Main itself).
+                        runCatching { newGenerator.close() }
+                        throw t
+                    }
+
+                    webPoTokenGenerator = newGenerator
+                    webPoTokenSessionPot = newSessionPot
+                    webPoTokenSessionId = sessionId
+                    Timber.tag(TAG).d("Session poToken generated for sessionId=${sessionId.take(20)}...")
                 }
 
                 Triple(webPoTokenGenerator!!, webPoTokenSessionPot!!, shouldRecreate)

--- a/library/src/main/kotlin/com/zemer/cipher/potoken/PoTokenWebView.kt
+++ b/library/src/main/kotlin/com/zemer/cipher/potoken/PoTokenWebView.kt
@@ -62,6 +62,8 @@ class PoTokenWebView private constructor(
         private set
     private val poTokenContinuations =
         Collections.synchronizedMap(ArrayMap<String, Continuation<String>>())
+    // Makes each generatePoToken call's continuation key unique (see generatePoToken).
+    private val requestCounter = java.util.concurrent.atomic.AtomicLong()
     private val exceptionHandler = CoroutineExceptionHandler { _, t ->
         onInitializationErrorCloseAndCancel(t)
     }
@@ -90,11 +92,27 @@ class PoTokenWebView private constructor(
 
                 if (msg.contains("Uncaught")) {
                     val fmt = "\"$msg\", source: ${m.sourceId()} (${m.lineNumber()})"
-                    val exception = BadWebViewException(fmt)
-                    Timber.tag(TAG).e("This WebView implementation is broken: $fmt")
+                    if (initResumed.get()) {
+                        // Post-init: our static HTML already executed fine, so an uncaught error
+                        // here comes from Google's remotely-served botguard/minter JS — transient,
+                        // NOT a BadWebViewException, which would permanently disable poTokens for
+                        // the session in PoTokenGenerator (same rationale as onRenderProcessGone).
+                        Timber.tag(TAG).e("Uncaught JS error after init (treating as transient): $fmt")
+                        isDead = true
+                        val exception = PoTokenException(fmt)
+                        close()
+                        popAllPoTokenContinuations().forEach { (_, cont) ->
+                            runCatching { cont.resumeWithException(exception) }
+                        }
+                    } else {
+                        val exception = BadWebViewException(fmt)
+                        Timber.tag(TAG).e("This WebView implementation is broken: $fmt")
 
-                    onInitializationErrorCloseAndCancel(exception)
-                    popAllPoTokenContinuations().forEach { (_, cont) -> cont.resumeWithException(exception) }
+                        onInitializationErrorCloseAndCancel(exception)
+                        popAllPoTokenContinuations().forEach { (_, cont) ->
+                            runCatching { cont.resumeWithException(exception) }
+                        }
+                    }
                 }
                 return super.onConsoleMessage(m)
             }
@@ -247,40 +265,47 @@ class PoTokenWebView private constructor(
             // WebView from scratch.
             throw PoTokenException("PoToken WebView is dead/closed — instance must be recreated")
         }
+        // Continuations are keyed by a per-call unique key, not the raw identifier: concurrent
+        // calls for the same videoId (player + prefetch/download) would otherwise silently
+        // overwrite each other's continuation and orphan one caller into the 15 s timeout.
+        val requestKey = "$identifier#${requestCounter.incrementAndGet()}"
         return try {
             withTimeout(GENERATE_TIMEOUT_MS) {
-                generatePoTokenInternal(identifier)
+                generatePoTokenInternal(identifier, requestKey)
             }
         } catch (e: TimeoutCancellationException) {
             // A renderer that never answers is wedged/dead (safety net for providers where
             // onRenderProcessGone doesn't fire) — drop the pending continuation and fail fast;
             // PoTokenGenerator's retry recreates the WebView from scratch.
             isDead = true
-            popPoTokenContinuation(identifier)
+            popPoTokenContinuation(requestKey)
             Timber.tag(TAG).e("generatePoToken($identifier) timed out after ${GENERATE_TIMEOUT_MS}ms")
             throw PoTokenException("poToken generation timed out after ${GENERATE_TIMEOUT_MS}ms")
         }
     }
 
-    private suspend fun generatePoTokenInternal(identifier: String): String {
+    private suspend fun generatePoTokenInternal(identifier: String, requestKey: String): String {
         return withContext(Dispatchers.Main) {
             suspendCancellableCoroutine { cont ->
                 Timber.tag(TAG).d("generatePoToken() called with identifier $identifier")
-                addPoTokenEmitter(identifier, cont)
-                // NOTE: obtainPoToken is now async, so we use .then()
+                addPoTokenEmitter(requestKey, cont)
+                // The IIFE keeps requestKey/u8Identifier lexically captured per call: bare globals
+                // here would let a concurrent call reassign them before this call's promise
+                // resolves, delivering this token to the other call's continuation.
                 webView.evaluateJavascript(
-                    """try {
-                        identifier = "$identifier"
-                        u8Identifier = ${stringToU8(identifier)}
-                        obtainPoToken(u8Identifier).then(function(poTokenU8) {
-                            poTokenU8String = poTokenU8.join(",")
-                            $JS_INTERFACE.onObtainPoTokenResult(identifier, poTokenU8String)
-                        }).catch(function(error) {
-                            $JS_INTERFACE.onObtainPoTokenError(identifier, error + "\n" + (error.stack || ''))
-                        })
-                    } catch (error) {
-                        $JS_INTERFACE.onObtainPoTokenError(identifier, error + "\n" + error.stack)
-                    }""",
+                    """(function() {
+                        var requestKey = "$requestKey"
+                        try {
+                            var u8Identifier = ${stringToU8(identifier)}
+                            obtainPoToken(u8Identifier).then(function(poTokenU8) {
+                                $JS_INTERFACE.onObtainPoTokenResult(requestKey, poTokenU8.join(","))
+                            }).catch(function(error) {
+                                $JS_INTERFACE.onObtainPoTokenError(requestKey, error + "\n" + (error.stack || ''))
+                            })
+                        } catch (error) {
+                            $JS_INTERFACE.onObtainPoTokenError(requestKey, error + "\n" + error.stack)
+                        }
+                    })()""",
                     null
                 )
             }
@@ -292,29 +317,33 @@ class PoTokenWebView private constructor(
      * JavaScript `obtainPoToken()` function.
      */
     @JavascriptInterface
-    fun onObtainPoTokenError(identifier: String, error: String) {
+    fun onObtainPoTokenError(requestKey: String, error: String) {
         if (ZemerCipher.debugLogging) {
             Timber.tag(TAG).e("obtainPoToken error from JavaScript: $error")
         }
-        popPoTokenContinuation(identifier)?.resumeWithException(buildExceptionForJsError(error))
+        // Always transient here: the minter was already created successfully, so even a
+        // "SyntaxError" comes from Google's challenge/program data, not a broken WebView engine —
+        // buildExceptionForJsError's BadWebViewException mapping would permanently disable
+        // poTokens for the session in PoTokenGenerator.
+        popPoTokenContinuation(requestKey)?.resumeWithException(PoTokenException(error))
     }
 
     /**
-     * Called by the JavaScript snippet from [generatePoToken] with the original identifier and the
+     * Called by the JavaScript snippet from [generatePoToken] with the per-call request key and the
      * result of the JavaScript `obtainPoToken()` function.
      */
     @JavascriptInterface
-    fun onObtainPoTokenResult(identifier: String, poTokenU8: String) {
-        Timber.tag(TAG).d("Generated poToken (before decoding): identifier=$identifier poTokenU8=$poTokenU8")
+    fun onObtainPoTokenResult(requestKey: String, poTokenU8: String) {
+        Timber.tag(TAG).d("Generated poToken (before decoding): requestKey=$requestKey poTokenU8=$poTokenU8")
         val poToken = try {
             u8ToBase64(poTokenU8)
         } catch (t: Throwable) {
-            popPoTokenContinuation(identifier)?.resumeWithException(t)
+            popPoTokenContinuation(requestKey)?.resumeWithException(t)
             return
         }
 
-        Timber.tag(TAG).d("Generated poToken: identifier=$identifier poToken=$poToken")
-        popPoTokenContinuation(identifier)?.resume(poToken)
+        Timber.tag(TAG).d("Generated poToken: requestKey=$requestKey poToken=$poToken")
+        popPoTokenContinuation(requestKey)?.resume(poToken)
     }
 
     val isExpired: Boolean
@@ -354,16 +383,16 @@ class PoTokenWebView private constructor(
                     "x-user-agent" to "grpc-web-javascript/0.1",
                 ).toHeaders())
                 .url(url)
-            val response = withContext(Dispatchers.IO) {
-                httpClient.newCall(requestBuilder.build()).execute()
+            // .use{} so the response is closed on the non-200 path too (an unread body would
+            // otherwise strand its connection).
+            val (httpCode, body) = withContext(Dispatchers.IO) {
+                httpClient.newCall(requestBuilder.build()).execute().use { response ->
+                    response.code to if (response.code == 200) response.body!!.string() else null
+                }
             }
-            val httpCode = response.code
-            if (httpCode != 200) {
+            if (body == null) {
                 onInitializationErrorCloseAndCancel(PoTokenException("Invalid response code: $httpCode"))
             } else {
-                val body = withContext(Dispatchers.IO) {
-                    response.body!!.string()
-                }
                 handleResponseBody(body)
             }
         }


### PR DESCRIPTION
## Summary

Fixes eight verified defects found in a full-codebase review of the cipher library, plus five follow-up findings from a second review pass of the fix branch itself. All changes are working-tree-verified on-device (see Validation).

### Correctness
- **PoTokenGenerator**: commit session state only after the session pot mint succeeds. Previously a failed mint left `sessionId` matching with a null/stale session pot — `KotlinNullPointerException` on first-run, or silently wrong-session tokens (403s) afterwards, with no self-heal. The freshly created WebView is now closed on mint failure instead of leaked.
- **PoTokenWebView**: pending mints are keyed by a per-call unique request key, captured lexically in the injected JS (IIFE). Concurrent mints (playback + download/prefetch) could previously swap tokens via the shared JS global `identifier` and orphan a caller into the 15s timeout, which then destroyed a healthy WebView.
- **PoTokenWebView**: post-init `Uncaught` console errors and mint-time JS errors are transient (`PoTokenException` + recreate) instead of `BadWebViewException`, which permanently disabled poTokens for the session — one transient hiccup in the remotely-served botguard JS used to degrade every stream until app restart. Init-phase broken-WebView detection is unchanged.
- **CipherWebView**: sig/n eval requests carry a request id echoed back by the JS bridge; a late result from a cancelled request can no longer resume the next request's continuation with the wrong signature (CDN 403).
- **CipherWebView.create()**: the half-initialized WebView is destroyed on any init failure — the `onPlayerJsError` path previously leaked one live renderer per retry.
- **PlayerConfigStore/PlayerJsFetcher**: all wall-clock cooldown/TTL checks go through a single `withinWindow` helper that treats a negative delta (backward clock step) as expired/not-armed. Previously an NTP correction could wedge the config self-heal for the entire skew — the persisted fetch stamp even across restarts.
- **PlayerJsFetcher**: cache writes are atomic (temp + rename) and serialized behind a lock (concurrent purge could otherwise delete the temp mid-write); `writeAtomic` retries the rename after deleting the target before falling back to a direct write. Process death mid-write could previously serve a truncated player.js for up to 6h.
- **FunctionNameExtractor**: `signatureTimestamp` precedence is anchored-JS-literal → config → loose pattern. The JS literal is the field configs are copied from at authoring time and, unlike sig/n, config sts is not CDN-validated — a bad remote push must not be authoritative.

### Resource/perf
- The ~2.8 MB player.js transform + disk write moved off the main thread (was blocking the UI on every WebView build); the player JS string is no longer retained for the WebView's lifetime (~2.8 MB heap).
- OkHttp responses are closed on non-success paths (connection leak on 403/429).

### Cleanup
- Duplicated sig/n continuation machinery folded into one `RequestSlot` class with distinctly named `takeIfCurrent`/`takeAny` (same-name overloads made dropping the id a silent way to reintroduce the race); redundant catch arm merged.

## Compatibility

No changes to the remote config schema, parser, bundled asset, or ETag protocol — existing installs keep fetching configs unchanged.

## Validation

- Full unit suite green on debug and release variants.
- On-device (CPH2583, fresh install + restart runs): 15/15 sig deciphers, 15/15 n-transforms, 16/16 poToken mints across 15 songs; request ids monotonic with every JS callback id-matched; single WebView build (50 ms IO-side prep); zero FATALs, renderer-gone, Uncaught, or BadWebView events in 22k log lines.