### PR TITLE
feat(ci): automated player-config rotation pipeline

### DIFF
--- a/.github/workflows/player-monitor.yml
+++ b/.github/workflows/player-monitor.yml
@@ -471,30 +471,37 @@ jobs:
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "pushed=true" >> "$GITHUB_OUTPUT"
 
-      # Read the deployed file back via the contents API, NOT raw.githubusercontent (the raw CDN
-      # lags ~5 min). CRITICAL: a failed READBACK is not proof of a bad deploy — the push already
-      # landed — so it must NEVER trigger the rollback. GitHub's API 5xx/secondary-rate-limits are
-      # common (we hit them repeatedly today), and the old `gh api | base64 -d` under pipefail would
-      # fail the step on any such blip and destructively revert a CORRECT deploy. So: retry the read
-      # with backoff, and set verified=false (the only rollback trigger) ONLY when a successfully
-      # read file is genuinely MISSING the hash. If the file can't be read after retries, warn and
-      # treat as unverified (verified=unknown) — leave the good deploy in place.
+      # Read the deployed file back via the GIT PROTOCOL at the pushed ref — NOT the REST contents
+      # API (and never raw.githubusercontent, which lags ~5 min). The contents API is CDN-cached and
+      # has read-your-writes lag: for minutes after a push it can SUCCESSFULLY return the STALE
+      # pre-push file, which then looks like the hash is "missing" and destructively reverts a
+      # CORRECT deploy (this is exactly what reverted 1a8bfffc on 2026-08-20 — push succeeded, the
+      # cached readback lacked the hash, and a good config was rolled back). Git protocol is
+      # immediately consistent — it is the same backend the push just wrote to — so it cannot serve a
+      # stale blob. CRITICAL (unchanged): a failed READBACK is not proof of a bad deploy — the push
+      # already landed — so it must NEVER trigger the rollback. Retry the read with backoff; set
+      # verified=false (the only rollback trigger) ONLY when a cleanly-read file is genuinely MISSING
+      # the hash. If it can't be read after retries, warn and treat as unverified (verified=unknown)
+      # — leave the good deploy in place.
       - name: Verify deployed file
         id: verify
         if: steps.apply.outputs.applied != ''
         env:
-          GH_TOKEN: ${{ steps.bot.outputs.token }}
+          BOT_TOKEN: ${{ steps.bot.outputs.token }}
           TARGET: ${{ steps.branch.outputs.target }}
           APPLIED: ${{ steps.apply.outputs.applied }}
         run: |
+          # Explicit token URL (the repo may be private; persist-credentials:false left none in
+          # .git/config). Same auth the Push/Revert steps use; the token is masked in logs.
+          REMOTE="https://x-access-token:${BOT_TOKEN}@github.com/${{ github.repository }}"
           read_ok=""
           for attempt in 1 2 3 4 5; do
-            if gh api "repos/${{ github.repository }}/contents/$CONFIG_PATH?ref=$TARGET" \
-                 --jq '.content' 2>/tmp/api.err | base64 -d > /tmp/deployed.json 2>/dev/null \
+            if git fetch --no-tags --force "$REMOTE" "$TARGET" 2>/tmp/git.err \
+               && git show "FETCH_HEAD:$CONFIG_PATH" > /tmp/deployed.json 2>/dev/null \
                && [ -s /tmp/deployed.json ] && node -e 'JSON.parse(require("fs").readFileSync("/tmp/deployed.json","utf8"))' 2>/dev/null; then
               read_ok=1; break
             fi
-            echo "::warning::contents-API read attempt $attempt failed: $(head -c 160 /tmp/api.err 2>/dev/null)"
+            echo "::warning::git read-back attempt $attempt failed: $(head -c 160 /tmp/git.err 2>/dev/null)"
             sleep $((attempt * 5))
           done
           if [ -z "$read_ok" ]; then

--- a/.github/workflows/player-monitor.yml
+++ b/.github/workflows/player-monitor.yml
@@ -1,0 +1,677 @@
+name: YouTube Player Monitor
+
+# Detects a rotated YouTube player_ias, derives + empirically validates its cipher config, and
+# (when enabled) commits it to this repo. Devices fetch library/src/main/assets/player_configs.json
+# from this repo at runtime, so a commit here IS the deploy — which is why the pipeline is split
+# into three jobs with the credential deliberately kept away from the untrusted half:
+#
+#   scan    permissions: {}        — no token, no secrets beyond the YouTube cookie. This is the
+#                                    ONLY job that evaluates 2.9 MB of obfuscated YouTube base.js
+#                                    in jsdom (which is NOT a security boundary): BOTH the derive
+#                                    (propose-config, in a scrubbed child process) and the
+#                                    independent re-verify (verify-entry) run here. It holds no
+#                                    write credential, so an eval-escape has nothing to steal.
+#   alert   permissions: issues    — the watchdog: issue + email. Runs even if deploy is disabled
+#                                    or fails, so a human always hears about it.
+#   deploy  permissions: contents  — holds the write token and NEVER evaluates player JS. It only
+#                                    appends the already-twice-verified entry (pure JSON/text +
+#                                    strict re-parse), runs the parser parity gate, and commits.
+#   notify  permissions: issues    — after deploy: closes the resolved detection issue and posts
+#                                    the outcome to Telegram.
+#
+# Deploy is OFF unless the repository variable AUTO_DEPLOY_CONFIG is set:
+#   (unset) — validate and alert only, write nothing.        <- default
+#   branch  — commit back onto the branch the run was triggered from (burn-in on a feature
+#             branch; devices are unaffected, and writing to master is explicitly refused).
+#   master  — commit straight to master (the live deploy).
+# That variable is the kill switch: clearing it stops all writing on the next run.
+
+"on":
+  schedule:
+    # NOTE: GitHub only runs `schedule` from the DEFAULT branch, so this activates on merge.
+    # Also note GitHub's scheduler is best-effort — measured on zemer-app, a */30 cron drifted a
+    # median +20m and once skipped 96 minutes. For a tighter cadence drive `repository_dispatch`
+    # from an external cron instead; this schedule is the floor, not the target.
+    - cron: '*/20 * * * *'
+  workflow_dispatch:
+  repository_dispatch:
+    types: [player-cron]
+  push:
+    # Lets the workflow be exercised on its own feature branch before it is merged. Deploy stays
+    # inert here because AUTO_DEPLOY_CONFIG is unset until someone deliberately sets it.
+    branches: ['feat/auto-player-config']
+
+# Serialize: an overlapping schedule + dispatch must not both scan, both see "no open issue", and
+# both open a duplicate — or worse, both try to append the same entry. Queue rather than cancel so
+# an in-progress deploy finishes cleanly.
+concurrency:
+  group: youtube-player-monitor
+  cancel-in-progress: false
+
+permissions: {}
+
+env:
+  HARNESS_REPO: ZemerTeam/zemer-app
+  CONFIG_PATH: library/src/main/assets/player_configs.json
+
+jobs:
+  # Guard the safety gates. tools.test.mjs exercises the append-only / alias-collision / ambiguity
+  # / CDN-verdict logic that stands between the pipeline and every device's config table; nothing
+  # else runs it, so run it FIRST and gate the rest of the pipeline on it. No secrets, no token,
+  # and no npm install — the pure predicates import only node builtins (jsdom is lazy-loaded and
+  # never touched by the tests).
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run tools unit tests
+        run: node --test tools/tools.test.mjs
+
+  scan:
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions: {}
+    outputs:
+      unknown_count: ${{ steps.scan.outputs.unknown_count }}
+      summary: ${{ steps.scan.outputs.summary }}
+      proposed: ${{ steps.propose.outputs.proposed }}
+      proposed_hashes: ${{ steps.propose.outputs.proposed_hashes }}
+    steps:
+      - name: Checkout zemer-cipher
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # The derivation/validation harness lives in zemer-app and is deliberately NOT copied here:
+      # the config validation rules already exist in two readers (the Kotlin PlayerConfigParser and
+      # tests/player-configs.mjs) pinned together by shared parity fixtures, and a third hand-made
+      # copy is how those drift apart. zemer-app is public, so this needs no credential.
+      - name: Checkout validation harness
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.HARNESS_REPO }}
+          path: harness
+          sparse-checkout: tests
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: |
+          npm ci --prefix harness/tests
+          npm ci --prefix tools --no-audit --no-fund
+
+      # Sample the live player surfaces MANY times. YouTube A/B-tests new players: a canary served
+      # ~1/6 of the time is missed ~83% of the time by a single sample and only surfaces once it has
+      # already rotated in, i.e. once playback is already breaking. "Known" is decided by the
+      # harness loader (the app's own validation rules) against THIS repo's config file, including
+      # md5 aliases. Non-zero exit means the committed file is itself invalid — devices would reject
+      # it wholesale, so a red run is the correct alarm for that.
+      - name: Scan live players
+        id: scan
+        run: |
+          node harness/tests/scan-live-players.mjs "$CONFIG_PATH" 30 > /tmp/scan.json 2> /tmp/scan.log
+          cat /tmp/scan.log
+          COUNT=$(node -e "process.stdout.write(String((JSON.parse(require('fs').readFileSync('/tmp/scan.json','utf8')).unknown||[]).length))")
+          echo "unknown_count=$COUNT" >> "$GITHUB_OUTPUT"
+          {
+            echo "summary<<SUMMARY_EOF"
+            node -e "const s=JSON.parse(require('fs').readFileSync('/tmp/scan.json','utf8'));console.log((s.unknown||[]).map(u=>'- '+u.hash+' (seen '+u.count+'x of '+s.samples+', md5 '+u.md5+', sts '+u.sts+')').join('\n'))"
+            echo "SUMMARY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # Derive + empirically validate each unknown player. HTTP 206 off the live CDN is ground
+      # truth — regex extraction is not, because several constant pairs can decipher correctly and
+      # only the server says which one it accepts. propose-config refuses to emit anything when more
+      # than one pair works.
+      #
+      # YT_COOKIE/YT_VISITOR_DATA are optional. Without them this runs in guest mode, which does
+      # reach 206 from a runner but is bot-gated on almost every video id (measured: 1 of 10 usable
+      # from Azure IPs). With a throwaway account's cookie any video works, including the configured
+      # VALIDATION_VIDEO_ID.
+      # Derive AND independently verify here, in the isolated permissions:{} job. BOTH untrusted
+      # jsdom evals (propose-config's child validator and verify-entry) run in the job that holds
+      # NO write credential — the deploy job that holds the app token never evaluates player JS.
+      # Only entries that pass two independently-written 206 checks are uploaded for deploy.
+      - name: Derive and independently verify unknown players
+        id: propose
+        if: steps.scan.outputs.unknown_count != '0'
+        env:
+          YT_COOKIE: ${{ secrets.YT_COOKIE }}
+          YT_VISITOR_DATA: ${{ secrets.YT_VISITOR_DATA }}
+          VALIDATION_VIDEO_IDS: ${{ vars.VALIDATION_VIDEO_IDS }}
+        run: |
+          # Entry files (consumed by deploy) live in /tmp/entries; verbose logs in /tmp/logs — so
+          # the uploaded artifact is ONLY clean {hash,entry} files, never the verdict blobs.
+          mkdir -p /tmp/entries /tmp/logs
+          PROPOSED=0
+          HASHES=""
+          for HASH in $(node -e "const s=JSON.parse(require('fs').readFileSync('/tmp/scan.json','utf8'));process.stdout.write((s.unknown||[]).map(u=>u.hash).join(' '))"); do
+            echo "::group::validate $HASH"
+            # 1) DERIVE + validate (propose-config spawns the harness validator in a scrubbed child).
+            if node tools/propose-config.mjs "$HASH" --harness harness --out "/tmp/entries/$HASH.json" > "/tmp/logs/$HASH.propose.json"; then
+              # 2) INDEPENDENTLY re-verify the derived entry with cipher's own implementation
+              #    (>=2 distinct signatures, real bytes drained). Two agreeing 206 checks, both in
+              #    this no-token job, gate the deploy.
+              if node tools/verify-entry.mjs --entry "/tmp/entries/$HASH.json" --harness harness > "/tmp/logs/$HASH.verify.json"; then
+                echo "validated + independently verified $HASH"
+                PROPOSED=$((PROPOSED+1))
+                HASHES="$HASHES $HASH"
+              else
+                echo "::warning::$HASH derived but FAILED independent verification — not deploying"
+                cat "/tmp/logs/$HASH.verify.json" || true
+                rm -f "/tmp/entries/$HASH.json"
+              fi
+            else
+              echo "::warning::could not validate $HASH — $(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('/tmp/logs/$HASH.propose.json','utf8')).reason||'unknown')" 2>/dev/null || echo 'see log')"
+            fi
+            cat "/tmp/logs/$HASH.propose.json" || true
+            echo "::endgroup::"
+          done
+          echo "proposed=$PROPOSED" >> "$GITHUB_OUTPUT"
+          echo "proposed_hashes=$(echo $HASHES | xargs)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload proposed entries
+        if: steps.propose.outputs.proposed != '' && steps.propose.outputs.proposed != '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: proposed-entries
+          path: /tmp/entries/*.json
+          retention-days: 7
+
+      - name: Upload scan result
+        if: steps.scan.outputs.unknown_count != '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: scan-result
+          path: /tmp/scan.json
+          retention-days: 7
+
+  # The watchdog. Runs whether or not deploy is enabled or succeeds, so a rotation is never silent.
+  alert:
+    needs: scan
+    if: needs.scan.outputs.unknown_count != '0'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: write
+    # JOB-level so the email step's `if` can read it. A step's OWN env is NOT in scope for that
+    # step's `if` (only workflow/job env is), so the previous step-scoped mirror always evaluated
+    # empty and the email never sent. secrets aren't usable in `if` directly, hence the mirror.
+    env:
+      GMAIL_USER: ${{ secrets.GMAIL_USERNAME }}
+    steps:
+      # Open issues as the Zemer-Dude GitHub App (logo avatar). No fallback: if the token can't be
+      # minted this job fails — Telegram (a separate job) and email still carry the alert.
+      - name: Generate Zemer App token
+        id: bot
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.ZEMER_APP_ID }}
+          private-key: ${{ secrets.ZEMER_APP_PRIVATE_KEY }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: scan-result
+          path: /tmp
+
+      - name: Open issues for unknown players
+        uses: actions/github-script@v7
+        env:
+          PROPOSED_HASHES: ${{ needs.scan.outputs.proposed_hashes }}
+          DEPLOY_MODE: ${{ vars.AUTO_DEPLOY_CONFIG }}
+        with:
+          github-token: ${{ steps.bot.outputs.token }}
+          script: |
+            const fs = require('fs');
+            const scan = JSON.parse(fs.readFileSync('/tmp/scan.json', 'utf8'));
+            const validated = new Set((process.env.PROPOSED_HASHES || '').split(/\s+/).filter(Boolean));
+            const mode = process.env.DEPLOY_MODE || '(disabled)';
+
+            // Dedup by issue TITLE across ALL open issues, not by label: issues opened by an app
+            // token can arrive label-less, so a label-filtered query returns nothing and every run
+            // opens a duplicate. paginate() so a long list can't hide a match past page 1.
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner, repo: context.repo.repo, state: 'open', per_page: 100,
+            });
+            const openTitles = new Set(openIssues.map(i => i.title));
+
+            for (const u of scan.unknown) {
+              const title = `New YouTube player detected: ${u.hash}`;
+              if (openTitles.has(title)) { console.log(`Issue already open for ${u.hash}, skipping.`); continue; }
+              const auto = validated.has(u.hash)
+                ? `- **Auto-validated**: yes (HTTP 206 confirmed). Deploy mode: \`${mode}\``
+                : `- **Auto-validated**: NO — needs a human. Run \`node tests/validate-player-config.mjs ${u.hash}\``;
+              const body = [
+                '## New YouTube Player JS Detected',
+                '',
+                `- **Player hash**: \`${u.hash}\``,
+                `- **MD5 fallback**: \`${u.md5}\``,
+                `- **sts**: \`${u.sts}\``,
+                `- **Observed this run**: seen ${u.count} of ${scan.samples} samples` +
+                  (u.count * 3 < scan.samples ? ' — low-rate **canary**, caught early before it rotates in' : ''),
+                auto,
+                `- **player_ias URL**: https://www.youtube.com/s/player/${u.hash}/player_ias.vflset/en_GB/base.js`,
+                '',
+                'Devices self-heal from `player_configs.json` on this repo\'s default branch within minutes; no APK release is needed.',
+              ].join('\n');
+
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo, title, body,
+                labels: ['player-update', 'cipher'],
+              });
+              console.log(`Opened issue: ${title}`);
+            }
+
+
+      # !cancelled(): the email must go out even if issue creation failed — the alert matters more.
+      # env.GMAIL_USER is the JOB-level mirror (see the job env above); secrets aren't usable in if.
+      - name: Send email notification
+        if: ${{ !cancelled() && env.GMAIL_USER != '' }}
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          secure: true
+          username: ${{ secrets.GMAIL_USERNAME }}
+          password: ${{ secrets.GMAIL_APP_PASSWORD }}
+          subject: "New YouTube player(s) detected — cipher update required"
+          to: dietdroidwp@gmail.com
+          from: Zemer CI <${{ secrets.GMAIL_USERNAME }}>
+          body: |
+            New / unknown YouTube player(s) detected by the multi-sample monitor.
+            (Low-rate hits are A/B canaries caught early, before they rotate in and break playback.)
+
+            ${{ needs.scan.outputs.summary }}
+
+            Auto-validated: ${{ needs.scan.outputs.proposed_hashes }}
+            Deploy mode:    ${{ vars.AUTO_DEPLOY_CONFIG }}
+
+            Issues: https://github.com/${{ github.repository }}/issues
+
+  deploy:
+    needs: scan
+    if: >-
+      needs.scan.outputs.proposed != '' && needs.scan.outputs.proposed != '0' &&
+      (vars.AUTO_DEPLOY_CONFIG == 'branch' || vars.AUTO_DEPLOY_CONFIG == 'master')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    outputs:
+      applied: ${{ steps.apply.outputs.applied }}
+      target: ${{ steps.branch.outputs.target }}
+      sha: ${{ steps.push.outputs.sha }}
+      verified: ${{ steps.verify.outputs.verified }}
+    steps:
+      # Commit as the Zemer-Dude GitHub App (logo avatar) when it's configured: set repo variable
+      # ZEMER_APP_ID and secret ZEMER_APP_PRIVATE_KEY. Until then this step is skipped and the job
+      # The deploy commits as the Zemer-Dude App. No fallback: if the token can't be minted the job
+      # FAILS rather than committing under any other identity.
+      - name: Generate Zemer App token
+        id: bot
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.ZEMER_APP_ID }}
+          private-key: ${{ secrets.ZEMER_APP_PRIVATE_KEY }}
+
+      # `branch` mode commits back onto the branch the run was triggered from, so the whole
+      # pipeline can be exercised on a feature branch without devices ever seeing the result.
+      # `master` mode is the live deploy.
+      # persist-credentials: false keeps the write token OUT of .git/config, so it is never on disk
+      # while the parser parity gate runs `./gradlew` (third-party Gradle plugins/deps executing in
+      # the token-holding job). The token is supplied explicitly only at the final push command.
+      - name: Checkout deploy target
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ vars.AUTO_DEPLOY_CONFIG == 'master' && 'master' || github.ref_name }}
+          token: ${{ steps.bot.outputs.token }}
+          persist-credentials: false
+          fetch-depth: 0
+
+      # Belt and braces: `branch` mode must never write to master, even if it is somehow triggered
+      # from there (a scheduled run, for instance, always fires on the default branch).
+      - name: Refuse to write to master in branch mode
+        if: vars.AUTO_DEPLOY_CONFIG == 'branch' && github.ref_name == 'master'
+        run: |
+          echo "::error::AUTO_DEPLOY_CONFIG=branch but this run was triggered from master — refusing to write"
+          exit 1
+
+      - name: Checkout validation harness
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.HARNESS_REPO }}
+          path: harness
+          sparse-checkout: tests
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      # No `npm ci` here on purpose: this job runs only apply-entry (imports the harness parser,
+      # node-builtins only) and gen-player-dates (git + builtins) — the jsdom-heavy verify-entry
+      # moved to the scan job. Not installing harness/tools deps keeps that whole transitive
+      # supply chain out of the job that holds the write token.
+      - uses: actions/download-artifact@v4
+        with:
+          name: proposed-entries
+          path: /tmp/entries
+
+      # The App's bot avatar is matched by the <uid>+<slug>[bot]@users.noreply.github.com author
+      # email; the uid is looked up at runtime from the token's own app-slug. No fallback identity:
+      # an empty app-slug means the token step failed, so fail here rather than commit as anyone else.
+      - name: Configure commit identity
+        env:
+          GH_TOKEN: ${{ steps.bot.outputs.token }}
+          APP_SLUG: ${{ steps.bot.outputs.app-slug }}
+        run: |
+          if [ -z "$APP_SLUG" ]; then
+            echo "::error::no Zemer-Dude App token — refusing to commit under any other identity"
+            exit 1
+          fi
+          uid="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          git config user.name "Zemer-Dude"
+          git config user.email "${uid}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git config --get user.name
+
+      - name: Resolve deploy target
+        id: branch
+        run: |
+          TARGET="${{ vars.AUTO_DEPLOY_CONFIG == 'master' && 'master' || github.ref_name }}"
+          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+          # The tip BEFORE any bot commit — the known-good SHA the revert step rolls back to.
+          echo "base_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "committing to '$TARGET' (base $(git rev-parse --short HEAD))"
+          git --no-pager log --oneline -1
+
+      # Each entry was already independently verified in the isolated scan job (two agreeing 206
+      # checks, both written by different code). This job holds the write credential and therefore
+      # NEVER evaluates player JS — it only appends the pre-verified entry, which apply-entry does
+      # with pure JSON/text ops plus a strict re-parse against the app's own rules.
+      - name: Apply verified entries
+        id: apply
+        run: |
+          APPLIED=""
+          for FILE in /tmp/entries/*.json; do
+            HASH=$(node -e "process.stdout.write(String(JSON.parse(require('fs').readFileSync('$FILE','utf8')).hash||''))")
+            [ -n "$HASH" ] || { echo "skipping non-entry file $FILE"; continue; }
+            echo "::group::apply $HASH"
+            APPLY=$(node tools/apply-entry.mjs --config "$CONFIG_PATH" --entry "$FILE" --harness harness)
+            echo "$APPLY"
+            if [ "$(echo "$APPLY" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>process.stdout.write(String(JSON.parse(s).noop)))")" = "true" ]; then
+              echo "$HASH already covered — nothing to do"
+              echo "::endgroup::"
+              continue
+            fi
+            git add "$CONFIG_PATH"
+            # [skip ci] is load-bearing: App-token pushes DO re-trigger workflows (unlike the
+            # default GITHUB_TOKEN), so without it this workflow re-runs on its own commit.
+            git commit -m "feat(configs): add player $HASH (sts $(node -e "process.stdout.write(String(JSON.parse(require('fs').readFileSync('$FILE','utf8')).entry.sts))")) [skip ci]"
+            APPLIED="$APPLIED $HASH"
+            echo "::endgroup::"
+          done
+          echo "applied=$(echo $APPLIED | xargs)" >> "$GITHUB_OUTPUT"
+
+      # The app's real parser, on the exact bytes about to be pushed. The harness parser already
+      # accepted them and shared fixtures pin the two together, but this is the one that runs on
+      # devices — worth 3 minutes before an unattended deploy.
+      - name: Parser parity gate
+        if: steps.apply.outputs.applied != ''
+        run: ./gradlew --no-daemon :library:test
+
+      - name: Refresh player_dates
+        if: steps.apply.outputs.applied != ''
+        continue-on-error: true
+        run: |
+          # Cosmetic only (a UI label); a failure here must never block a config deploy.
+          #
+          # gen-player-dates.mjs is written for the zemer-app layout: it hardcodes `cipher/` as the
+          # repo root (readFileSync("cipher/library/...") and `git -C cipher log`). Running it from
+          # this repo therefore needs that name to exist. Rather than fork the script — it is the
+          # single source for how a support date is derived — run it from a scratch directory whose
+          # `cipher` entry points back at the workspace. The symlink lives outside the repo, so the
+          # working tree stays clean.
+          if [ -f harness/tests/gen-player-dates.mjs ]; then
+            mkdir -p /tmp/dates
+            ln -sfn "$GITHUB_WORKSPACE" /tmp/dates/cipher
+            (cd /tmp/dates && node "$GITHUB_WORKSPACE/harness/tests/gen-player-dates.mjs") || \
+              echo "::warning::player_dates refresh failed — config deploy is unaffected"
+            if ! git diff --quiet player_dates.json; then
+              git add player_dates.json
+              git commit -m "config: refresh player_dates for ${{ steps.apply.outputs.applied }} [skip ci]"
+            fi
+          fi
+
+      - name: Push
+        id: push
+        if: steps.apply.outputs.applied != ''
+        env:
+          BOT_TOKEN: ${{ steps.bot.outputs.token }}
+          TARGET: ${{ steps.branch.outputs.target }}
+        run: |
+          # Explicit token URL because persist-credentials:false left none in .git/config. The
+          # token is a masked secret, so it does not leak in logs.
+          git push "https://x-access-token:${BOT_TOKEN}@github.com/${{ github.repository }}" "HEAD:${TARGET}"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
+      # Read the deployed file back via the contents API, NOT raw.githubusercontent (the raw CDN
+      # lags ~5 min). CRITICAL: a failed READBACK is not proof of a bad deploy — the push already
+      # landed — so it must NEVER trigger the rollback. GitHub's API 5xx/secondary-rate-limits are
+      # common (we hit them repeatedly today), and the old `gh api | base64 -d` under pipefail would
+      # fail the step on any such blip and destructively revert a CORRECT deploy. So: retry the read
+      # with backoff, and set verified=false (the only rollback trigger) ONLY when a successfully
+      # read file is genuinely MISSING the hash. If the file can't be read after retries, warn and
+      # treat as unverified (verified=unknown) — leave the good deploy in place.
+      - name: Verify deployed file
+        id: verify
+        if: steps.apply.outputs.applied != ''
+        env:
+          GH_TOKEN: ${{ steps.bot.outputs.token }}
+          TARGET: ${{ steps.branch.outputs.target }}
+          APPLIED: ${{ steps.apply.outputs.applied }}
+        run: |
+          read_ok=""
+          for attempt in 1 2 3 4 5; do
+            if gh api "repos/${{ github.repository }}/contents/$CONFIG_PATH?ref=$TARGET" \
+                 --jq '.content' 2>/tmp/api.err | base64 -d > /tmp/deployed.json 2>/dev/null \
+               && [ -s /tmp/deployed.json ] && node -e 'JSON.parse(require("fs").readFileSync("/tmp/deployed.json","utf8"))' 2>/dev/null; then
+              read_ok=1; break
+            fi
+            echo "::warning::contents-API read attempt $attempt failed: $(head -c 160 /tmp/api.err 2>/dev/null)"
+            sleep $((attempt * 5))
+          done
+          if [ -z "$read_ok" ]; then
+            echo "::warning::could not read back the deployed file after retries — the push landed (git confirmed), treating as UNVERIFIED, NOT reverting"
+            echo "verified=unknown" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          MISSING=$(node -e '
+            const fs = require("fs");
+            const d = JSON.parse(fs.readFileSync("/tmp/deployed.json", "utf8"));
+            const hashes = process.argv[1].split(/\s+/).filter(Boolean);
+            process.stdout.write(hashes.filter((h) => !d.players[h]).join(","));
+          ' "$APPLIED")
+          if [ -n "$MISSING" ]; then
+            echo "::error::deployed file is genuinely MISSING: $MISSING — rolling back"
+            echo "verified=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          echo "verified $APPLIED present on $TARGET ($(node -e 'process.stdout.write(String(Object.keys(JSON.parse(require("fs").readFileSync("/tmp/deployed.json","utf8")).players).length))') entries)"
+          echo "verified=true" >> "$GITHUB_OUTPUT"
+
+      # Roll back ONLY on a PROVEN bad deploy (verified=='false': the file was read cleanly and the
+      # hash is truly absent) — never on a mere API/read failure. Revert base_sha..HEAD as one
+      # [skip ci] commit (no history rewrite, correct for any number of commits). Retry the rollback
+      # push, refetching on a non-fast-forward so a concurrent commit can't strand the bad config.
+      - name: Revert on proven bad deploy
+        if: always() && steps.verify.outputs.verified == 'false'
+        env:
+          BOT_TOKEN: ${{ steps.bot.outputs.token }}
+          TARGET: ${{ steps.branch.outputs.target }}
+          BASE_SHA: ${{ steps.branch.outputs.base_sha }}
+        run: |
+          REMOTE="https://x-access-token:${BOT_TOKEN}@github.com/${{ github.repository }}"
+          for attempt in 1 2 3; do
+            git revert --no-edit --no-commit "${BASE_SHA}..HEAD" 2>/dev/null || true
+            git commit -m "revert: roll back failed player deploy [skip ci]" 2>/dev/null || true
+            if git push "$REMOTE" "HEAD:${TARGET}"; then
+              echo "::error::rolled back the bad deploy to ${BASE_SHA}"
+              exit 0
+            fi
+            echo "::warning::rollback push failed (attempt $attempt) — refetching $TARGET and retrying"
+            git fetch "$REMOTE" "$TARGET" && git reset --hard FETCH_HEAD
+            sleep 5
+          done
+          echo "::error::COULD NOT roll back the bad deploy after retries — manual intervention required"
+          exit 1
+
+  # Telegram reports what the bot actually DID, so it has to wait for deploy — the alert job runs
+  # in parallel with it and cannot know the outcome. always() so a failed or skipped deploy is
+  # still reported: silence after a detected rotation is the one thing this must never do.
+  notify:
+    needs: [scan, alert, deploy]
+    if: always() && needs.scan.outputs.unknown_count != '0'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      # Close EVERY open detection issue whose hash is now covered on this repo's master — which
+      # covers all the ways one can be resolved: auto-deployed this run, deployed by hand
+      # out-of-band (deploy no-op), or a leftover duplicate. `needs: alert` makes this run AFTER the
+      # (fast, parallel) alert job, so the issue it opens always exists by now — the previous
+      # deploy-only race (deploy finishing before alert created the issue) is gone. Reads coverage
+      # from master itself rather than trusting deploy.applied, so a no-op deploy still closes.
+      #
+      # Uses the built-in GITHUB_TOKEN (issues:write via this job's permissions); the Zemer-Dude App
+      # token is NOT granted comment/close ('Resource not accessible by integration'), and closing
+      # needs no bot identity. continue-on-error so a hiccup here can never fail the run or block the
+      # Telegram alert below. REST (comment POST + state PATCH).
+      - name: Close resolved detection issues
+        if: always()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ needs.deploy.outputs.sha }}
+          REPO: ${{ github.repository }}
+          CONFIG_PATH: ${{ env.CONFIG_PATH }}
+        run: |
+          # The accepted key space on master (primaries + md5 aliases).
+          gh api "repos/$REPO/contents/$CONFIG_PATH?ref=master" --jq '.content' 2>/dev/null | base64 -d > /tmp/master.json || { echo "::warning::could not read master config — skipping issue cleanup"; exit 0; }
+          COVERED=$(node -e '
+            const d = JSON.parse(require("fs").readFileSync("/tmp/master.json","utf8"));
+            const s = new Set();
+            for (const [k,e] of Object.entries(d.players)) { s.add(k); for (const a of (e.aliases||[])) s.add(a); }
+            process.stdout.write([...s].join(" "));
+          ')
+          gh issue list --repo "$REPO" --state open --limit 100 --json number,title \
+            --jq '.[] | select(.title | test("^New YouTube player detected: [a-f0-9]{8}$")) | [.number, (.title | sub("New YouTube player detected: "; ""))] | @tsv' \
+          | while IFS=$'\t' read -r NUM HASH; do
+              case " $COVERED " in
+                *" $HASH "*)
+                  gh api --method POST "repos/$REPO/issues/$NUM/comments" \
+                    -f body="Resolved — \`${HASH}\` is now on master${SHA:+ (${SHA})}. Devices self-heal within minutes." \
+                    || echo "::warning::could not comment on #$NUM"
+                  gh api --method PATCH "repos/$REPO/issues/$NUM" -f state=closed \
+                    && echo "closed #$NUM ($HASH)" || echo "::warning::could not close #$NUM" ;;
+                *) echo "#$NUM ($HASH) not yet on master — leaving open" ;;
+              esac
+            done
+
+      # Same shape as zemer-app's release-build.yml: curl to the Bot API, recipients = the primary
+      # chat (TELEGRAM_CHAT_ID secret) plus any added users in the TELEGRAM_CHAT_IDS repo variable
+      # (comma / space / newline separated), deduped, blanks dropped. To add a user: they open the
+      # bot and press Start, then add their numeric chat id to that variable.
+      #
+      # Every `${{ }}` value goes through env: and is read as a quoted shell var rather than being
+      # inlined, so free text can never break or inject into the script.
+      - name: Send Telegram notification
+        # always(): the alert is this job's whole purpose — nothing before it (token mint, issue
+        # cleanup) may ever skip it.
+        if: always()
+        env:
+          BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          PRIMARY_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          EXTRA_CHAT_IDS: ${{ vars.TELEGRAM_CHAT_IDS }}
+          # A forum group routes to a specific topic by message_thread_id; leave unset to post to
+          # General / a non-forum chat. Applies only to the PRIMARY chat (the group), not the
+          # per-user DMs in EXTRA_CHAT_IDS.
+          THREAD_ID: ${{ vars.TELEGRAM_THREAD_ID }}
+          SUMMARY: ${{ needs.scan.outputs.summary }}
+          VALIDATED: ${{ needs.scan.outputs.proposed_hashes }}
+          UNKNOWN_COUNT: ${{ needs.scan.outputs.unknown_count }}
+          DEPLOY_MODE: ${{ vars.AUTO_DEPLOY_CONFIG }}
+          DEPLOY_RESULT: ${{ needs.deploy.result }}
+          APPLIED: ${{ needs.deploy.outputs.applied }}
+          VERIFIED: ${{ needs.deploy.outputs.verified }}
+          TARGET: ${{ needs.deploy.outputs.target }}
+          SHA: ${{ needs.deploy.outputs.sha }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "$BOT_TOKEN" ]; then
+            echo "No TELEGRAM_BOT_TOKEN — skipping Telegram."
+            exit 0
+          fi
+
+          # The headline is the OUTCOME, not the detection: with auto-commit on, "a player was
+          # detected" is no longer the news — whether it got deployed is.
+          if [ "$DEPLOY_RESULT" = "success" ] && [ -n "$APPLIED" ]; then
+            HEAD_LINE="Player config deployed"
+            ACTION=$(printf "Committed: %s\nBranch: %s\nCommit: %s/commit/%s" \
+              "$APPLIED" "$TARGET" "$REPO_URL" "$SHA")
+          elif [ "$DEPLOY_RESULT" = "success" ]; then
+            HEAD_LINE="Player already covered"
+            ACTION="Nothing to commit — the config was already on the deploy branch."
+          elif [ "$DEPLOY_RESULT" = "failure" ] && [ "$VERIFIED" = "false" ]; then
+            # The config WAS pushed, then post-deploy verification proved it wrong and the rollback
+            # ran. Do NOT say "nothing was written" — a commit reached master and was reverted.
+            HEAD_LINE="Player config deploy FAILED — rolled back"
+            ACTION=$(printf "Committed %s to %s then verification found it MISSING; an automatic rollback ran. Confirm master is clean. Needs a human." \
+              "${APPLIED:-?}" "$TARGET")
+          elif [ "$DEPLOY_RESULT" = "failure" ]; then
+            HEAD_LINE="Player config deploy FAILED"
+            ACTION="Validation or a pre-push gate rejected it; nothing was pushed. Needs a human."
+          elif [ "$DEPLOY_RESULT" = "skipped" ] && [ -n "$VALIDATED" ]; then
+            HEAD_LINE="Player validated, NOT deployed"
+            ACTION=$(printf "Auto-deploy is off (AUTO_DEPLOY_CONFIG=%s). Validated but not committed." \
+              "${DEPLOY_MODE:-unset}")
+          else
+            HEAD_LINE="New player could NOT be auto-validated"
+            ACTION="No entry passed the 206 check. Needs a human: node tests/validate-player-config.mjs <hash>"
+          fi
+
+          MESSAGE=$(printf "%s\n\nDetected (%s):\n%s\n\nAuto-validated: %s\n\n%s\n\nRun: %s" \
+            "$HEAD_LINE" "$UNKNOWN_COUNT" "$SUMMARY" "${VALIDATED:-none}" "$ACTION" "$RUN_URL")
+
+          RECIPIENTS=$(printf '%s %s' "$PRIMARY_CHAT_ID" "$EXTRA_CHAT_IDS" \
+            | tr ',\n' '  ' | tr -s ' ' '\n' | awk 'NF && !seen[$0]++')
+
+          for CID in $RECIPIENTS; do
+            # The topic thread applies only to the primary (group) chat; a DM has no topics.
+            THREAD_ARG=()
+            if [ -n "$THREAD_ID" ] && [ "$CID" = "$PRIMARY_CHAT_ID" ]; then
+              THREAD_ARG=(-d "message_thread_id=${THREAD_ID}")
+            fi
+            curl -s -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" \
+              -d chat_id="$CID" \
+              "${THREAD_ARG[@]}" \
+              --data-urlencode "text=${MESSAGE}"
+          done

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tools/apply-entry.mjs
+++ b/tools/apply-entry.mjs
@@ -1,0 +1,178 @@
+// Append a verified entry to player_configs.json — append-only, format-preserving, re-parsed.
+//
+// This is the ONLY writer. Devices fetch this exact file from cipher master and self-heal from it
+// within minutes, so an unattended write has to be provably additive:
+//
+//   * APPEND-ONLY. Every pre-existing player key must survive byte-identically, `schemaVersion`
+//     must not move, and exactly one key may appear. Anything else aborts without writing.
+//   * NO COLLISIONS. The new hash and each of its aliases must not already exist as a primary key
+//     or as any other entry's alias — a duplicate key or alias makes the app reject the WHOLE file
+//     and keep its last-good table, i.e. it would silently freeze every device's config.
+//   * RE-PARSED. The serialized text is fed back through the harness parser (the same rules the
+//     app's PlayerConfigParser applies) before it is written, so we never commit a file the app
+//     would refuse.
+//
+// Formatting is emitted by hand rather than via JSON.stringify: the file is one line per player,
+// and reflowing 260 entries would bury a one-line change in an unreviewable diff.
+//
+//   node tools/apply-entry.mjs --config <path> --entry entry.json --harness <dir> [--dry-run]
+
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const HASH_RE = /^[a-f0-9]{8}$/;
+
+/** Every hash a device would accept from this table: primaries plus aliases. */
+export function coveredKeys(players) {
+  const keys = new Set();
+  for (const [primary, entry] of Object.entries(players)) {
+    keys.add(primary);
+    for (const alias of entry.aliases ?? []) keys.add(alias);
+  }
+  return keys;
+}
+
+/** Reject anything that is not a clean addition. Pure — this is the safety gate worth testing. */
+export function checkAppendOnly(before, after, newHash) {
+  if (before.schemaVersion !== after.schemaVersion) {
+    return { ok: false, reason: `schemaVersion changed ${before.schemaVersion} -> ${after.schemaVersion}` };
+  }
+  const beforeKeys = Object.keys(before.players);
+  const afterKeys = Object.keys(after.players);
+  const added = afterKeys.filter((k) => !beforeKeys.includes(k));
+  const removed = beforeKeys.filter((k) => !afterKeys.includes(k));
+
+  if (removed.length) return { ok: false, reason: `entries removed: ${removed.join(",")}` };
+  if (added.length !== 1) return { ok: false, reason: `expected exactly 1 new entry, got ${added.length}` };
+  if (added[0] !== newHash) return { ok: false, reason: `added '${added[0]}', expected '${newHash}'` };
+
+  for (const key of beforeKeys) {
+    const a = JSON.stringify(before.players[key]);
+    const b = JSON.stringify(after.players[key]);
+    if (a !== b) return { ok: false, reason: `existing entry '${key}' was modified` };
+  }
+  return { ok: true };
+}
+
+/**
+ * Is this entry already covered by the table — as its primary hash OR any of its md5 aliases?
+ * Used to classify a collision as a NO-OP (already deployed, incl. an earlier same-md5 skin in
+ * the same batch) rather than a hard error. Pure.
+ */
+export function entryAlreadyCovered(players, hash, aliases = []) {
+  const covered = coveredKeys(players);
+  return covered.has(hash) || aliases.some((a) => covered.has(a));
+}
+
+/** Collision check against the whole accepted key space, not just primary keys. */
+export function checkNoCollision(players, hash, aliases) {
+  const covered = coveredKeys(players);
+  if (covered.has(hash)) return { ok: false, reason: `hash '${hash}' is already covered` };
+  for (const alias of aliases) {
+    if (covered.has(alias)) return { ok: false, reason: `alias '${alias}' is already covered` };
+  }
+  if (new Set(aliases).size !== aliases.length) {
+    return { ok: false, reason: "entry has duplicate aliases" };
+  }
+  return { ok: true };
+}
+
+/** One line per player, matching the committed file byte-for-byte in shape. */
+export function serializeEntry(hash, entry) {
+  const aliases = entry.aliases ?? [];
+  const aliasPart = aliases.length ? `, "aliases": [${aliases.map((a) => `"${a}"`).join(", ")}]` : "";
+  return `    "${hash}": { "sig": "${entry.sig}", "nClass": "${entry.nClass}", "sts": ${entry.sts}${aliasPart} }`;
+}
+
+/**
+ * Insert the new line after the current last player line, adding the comma the previous last line
+ * now needs. Text-level so untouched lines stay untouched in the diff.
+ */
+export function insertEntryLine(text, hash, entry) {
+  const lines = text.split("\n");
+  let lastPlayerIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (/^\s+"[a-f0-9]{8}":\s*\{/.test(lines[i])) lastPlayerIdx = i;
+  }
+  if (lastPlayerIdx < 0) throw new Error("no existing player lines found — refusing to write");
+  if (!/,\s*$/.test(lines[lastPlayerIdx])) lines[lastPlayerIdx] += ",";
+  lines.splice(lastPlayerIdx + 1, 0, serializeEntry(hash, entry));
+  return lines.join("\n");
+}
+
+function arg(name, fallback = null) {
+  const i = process.argv.indexOf(name);
+  return i > 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+async function main() {
+  const configPath = arg("--config", "library/src/main/assets/player_configs.json");
+  const entryFile = arg("--entry");
+  const harnessDir = arg("--harness", "harness");
+  const dryRun = process.argv.includes("--dry-run");
+  if (!entryFile) {
+    console.error("usage: node tools/apply-entry.mjs --config <path> --entry entry.json --harness <dir>");
+    process.exit(1);
+  }
+
+  const { hash, entry } = JSON.parse(readFileSync(entryFile, "utf8"));
+  if (!HASH_RE.test(hash)) throw new Error(`bad hash '${hash}'`);
+
+  const originalText = readFileSync(configPath, "utf8");
+  const before = JSON.parse(originalText);
+
+  const collision = checkNoCollision(before.players, hash, entry.aliases ?? []);
+  if (!collision.ok) {
+    // Already covered is a NO-OP, not a failure: master moves out-of-band when a rotation is
+    // deployed by hand, and the pipeline must never treat that as an error to retry forever.
+    // "Covered" means the whole accepted key space — the primary hash OR any of the entry's md5
+    // aliases already present. Two byte-identical skins in ONE batch share an md5 alias: once the
+    // first is applied, the second is genuinely redundant (a device computes the same md5 and
+    // resolves it), so it must exit 0 (noop) — NOT exit 1, which under `set -e` would abort the
+    // whole deploy apply loop and discard the first, already-applied entry.
+    const alreadyCovered = entryAlreadyCovered(before.players, hash, entry.aliases ?? []);
+    console.log(JSON.stringify({ ok: false, noop: alreadyCovered, reason: collision.reason }, null, 2));
+    process.exit(alreadyCovered ? 0 : 1);
+  }
+
+  const nextText = insertEntryLine(originalText, hash, entry);
+
+  let after;
+  try {
+    after = JSON.parse(nextText);
+  } catch (e) {
+    throw new Error(`result is not valid JSON: ${e.message}`);
+  }
+
+  const appendOnly = checkAppendOnly(before, after, hash);
+  if (!appendOnly.ok) throw new Error(appendOnly.reason);
+
+  // Final gate: the app's own accept rules, applied to the exact bytes we are about to commit.
+  const { parsePlayerConfigs } = await import(
+    pathToFileURL(path.resolve(harnessDir, "tests", "player-configs.mjs")).href
+  );
+  const parsed = parsePlayerConfigs(nextText, configPath);
+  if (!parsed[hash]) throw new Error("parser did not accept the new entry");
+  const parsedCount = Object.keys(parsed).length;
+  const beforeCount = Object.keys(before.players).length;
+  if (parsedCount !== beforeCount + 1) {
+    throw new Error(`parser accepted ${parsedCount} entries, expected ${beforeCount + 1}`);
+  }
+
+  if (!dryRun) writeFileSync(configPath, nextText);
+  console.log(
+    JSON.stringify(
+      { ok: true, noop: false, hash, entry, entries: parsedCount, dryRun, line: serializeEntry(hash, entry).trim() },
+      null,
+      2,
+    ),
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((e) => {
+    console.log(JSON.stringify({ ok: false, reason: e.message }, null, 2));
+    process.exit(1);
+  });
+}

--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -1,0 +1,516 @@
+{
+  "name": "zemer-cipher-tools",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "zemer-cipher-tools",
+      "dependencies": {
+        "jsdom": "^29.1.1"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "zemer-cipher-tools",
+  "private": true,
+  "type": "module",
+  "description": "Automation tooling for the player_configs.json rotation workflow.",
+  "dependencies": {
+    "jsdom": "^29.1.1"
+  }
+}

--- a/tools/propose-config.mjs
+++ b/tools/propose-config.mjs
@@ -1,0 +1,264 @@
+// Propose a player_configs.json entry for an unknown player hash.
+//
+// Runs the zemer-app harness validator (tests/validate-player-config.mjs — the same tool the
+// manual rotation runbook uses, so there is no second copy of the derivation rules) as a CHILD
+// PROCESS WITH A SCRUBBED ENVIRONMENT, then applies the stricter rules an unattended pipeline
+// needs on top of the human one:
+//
+//   * AMBIGUITY REFUSAL. The harness validator stops at the first candidate pair that returns
+//     206 and prints it. Multiple constant pairs CAN decipher correctly, and picking the wrong
+//     one ships a config that works today and breaks on the next player skin. If more than one
+//     pair reports "WORKS" we refuse to propose anything and let a human look.
+//   * SHAPE VALIDATION. The parsed entry must satisfy the same regexes the app's
+//     PlayerConfigParser enforces, before it is ever written anywhere.
+//
+// The child gets no inherited environment: the untrusted 2.9 MB of obfuscated YouTube base.js is
+// evaluated in jsdom, which is explicitly NOT a security boundary, so it must not be able to read
+// whatever the runner happens to be holding. Only the variables listed in CHILD_ENV_ALLOWLIST are
+// forwarded, and each is either inert or a credential the validation genuinely needs.
+//
+//   node tools/propose-config.mjs <hash> --harness <dir> [--out entry.json]
+//
+// stdout: JSON { ok, hash, entry, reason, attempts, workingPairs }
+// exit 0 when a single validated entry was produced, 1 otherwise (including refusals).
+
+import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+
+// ADVISORY pre-filter only. These mirror PlayerConfigParser's shape rules so an obviously-malformed
+// validator line is rejected before it travels further, but they are NOT the authority and are
+// deliberately NOT pinned by the config-parity fixtures (those pin the Kotlin parser and
+// tests/player-configs.mjs). The authoritative acceptance is done downstream by verify-entry (live
+// 206) and apply-entry, which re-parses the exact bytes with the real parsePlayerConfigs. So if
+// these regexes ever drift from the app's rules the worst case is an over-reject (a valid rotation
+// punted to a human), never a bad deploy.
+const HASH_RE = /^[a-f0-9]{8}$/;
+const SIG_RE = /^[A-Za-z0-9$_]{1,8}\(\d+,\d+,INPUT\)$/;
+const NCLASS_RE = /^[A-Za-z0-9$_]{1,8}$/;
+
+// PATH/HOME so node can start and npm's resolution works; the YT_* trio is the credential the
+// validator needs to reach a signatureCipher (absent = guest mode, which is the default).
+// VALIDATION_VIDEO_ID is what the harness validator reads; VALIDATION_VIDEO_IDS is the operator's
+// comma-list override — childEnv() derives the singular from the first of the plural (see below),
+// so one repo var (VALIDATION_VIDEO_IDS) drives BOTH the derive step and verify-entry.
+const CHILD_ENV_ALLOWLIST = [
+  "PATH",
+  "HOME",
+  "NODE_PATH",
+  "YT_COOKIE",
+  "YT_VISITOR_DATA",
+  "YT_DATASYNC_ID",
+  "COOKIE_FILE",
+  "VALIDATION_VIDEO_ID",
+];
+
+const WORKS_MARKER = "✓ WORKS";
+const RESULT_MARKER = "VALIDATOR_RESULT=";
+const CHILD_TIMEOUT_MS = 180_000;
+// The validator logs a line per candidate pair while evaluating 2.9 MB of base.js; 2 MiB leaves
+// generous headroom above the real output (a few KB) without letting a runaway stream grow unbounded.
+const MAX_OUTPUT_BYTES = 2 * 1024 * 1024;
+
+/**
+ * The env handed to the untrusted child: allowlisted keys only, never process.env wholesale.
+ * The harness validator reads VALIDATION_VIDEO_ID (singular, one video); the operator-facing
+ * override is VALIDATION_VIDEO_IDS (plural, comma list, also consumed by verify-entry). Translate
+ * the first of the plural into the singular the validator understands, unless the singular is set
+ * explicitly.
+ */
+export function childEnv(source = process.env) {
+  const env = {};
+  for (const key of CHILD_ENV_ALLOWLIST) {
+    if (source[key] != null && source[key] !== "") env[key] = source[key];
+  }
+  if (!env.VALIDATION_VIDEO_ID && source.VALIDATION_VIDEO_IDS) {
+    const first = source.VALIDATION_VIDEO_IDS.split(",").map((v) => v.trim()).filter(Boolean)[0];
+    if (first) env.VALIDATION_VIDEO_ID = first;
+  }
+  return env;
+}
+
+/**
+ * Decide what the validator's output means. Pure — this is the part worth unit-testing, and it
+ * is where the unattended pipeline is stricter than the human runbook.
+ */
+export function interpretValidatorOutput(hash, stdout) {
+  const lines = stdout.split(/\r?\n/).map((line) => line.trim());
+
+  // Preferred path: the validator's structured VALIDATOR_RESULT line — a stable machine contract,
+  // NOT scraped human text. This is what makes the pipeline robust to log-format changes.
+  const resultLine = lines.find((line) => line.startsWith(RESULT_MARKER));
+  if (resultLine) {
+    let r;
+    try {
+      r = JSON.parse(resultLine.slice(RESULT_MARKER.length));
+    } catch (e) {
+      return { ok: false, reason: `${RESULT_MARKER} is not valid JSON: ${e.message}` };
+    }
+    if (r.hash !== hash) {
+      return { ok: false, reason: `${RESULT_MARKER} hash '${r.hash}' != requested '${hash}'` };
+    }
+    if (r.ambiguous) {
+      // More than one candidate both deciphered AND ran a real n-transform: refuse rather than
+      // guess which one the server truly accepts.
+      return { ok: false, reason: `ambiguous: ${r.workingCount} candidate pairs validated`, workingPairs: [] };
+    }
+    if (!r.ok || !r.entry) {
+      return { ok: false, reason: `no candidate pair returned 206 (workingCount=${r.workingCount ?? 0})` };
+    }
+    const shape = validateEntryShape(hash, r.entry);
+    if (!shape.ok) return { ok: false, reason: shape.reason };
+    return { ok: true, entry: r.entry };
+  }
+
+  // Fallback (an older validator without the structured line): scrape, but count ONLY candidates
+  // that both 206'd AND ran a real n-transform. A correct-sig / wrong-n pair also returns 206 in
+  // googlevideo's first-1-MiB free window and still prints "✓ WORKS", so counting bare WORKS lines
+  // over-refuses a clean single-winner rotation as "ambiguous".
+  const workingPairs = lines
+    .filter((line) => line.includes(WORKS_MARKER) && /nProbe\.changed=true/.test(line));
+
+  if (workingPairs.length === 0) {
+    return { ok: false, reason: "no candidate pair returned 206", workingPairs };
+  }
+  if (workingPairs.length > 1) {
+    return {
+      ok: false,
+      reason: `ambiguous: ${workingPairs.length} candidate pairs validated`,
+      workingPairs,
+    };
+  }
+
+  // The validator prints exactly one paste-ready entry line:
+  //     "b0d2d49a": { "sig": "EP(3,4223,INPUT)", "nClass": "eg", "sts": 20676, "aliases": ["6fd8f6f9"] }
+  const entryLine = lines.find((line) => new RegExp(`^"${hash}":\\s*\\{`).test(line));
+  if (!entryLine) {
+    return { ok: false, reason: "validator reported a winner but printed no entry line", workingPairs };
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(`{${entryLine}}`);
+  } catch (e) {
+    return { ok: false, reason: `entry line is not valid JSON: ${e.message}`, workingPairs };
+  }
+
+  const entry = parsed[hash];
+  const shape = validateEntryShape(hash, entry);
+  if (!shape.ok) return { ok: false, reason: shape.reason, workingPairs };
+
+  return { ok: true, entry, workingPairs };
+}
+
+/** Enforce the app's own accept rules before the entry is allowed anywhere near the config file. */
+export function validateEntryShape(hash, entry) {
+  if (!HASH_RE.test(hash)) return { ok: false, reason: `bad player hash '${hash}'` };
+  if (!entry || typeof entry !== "object") return { ok: false, reason: "entry is not an object" };
+  if (!SIG_RE.test(entry.sig ?? "")) return { ok: false, reason: `bad sig '${entry.sig}'` };
+  if (!NCLASS_RE.test(entry.nClass ?? "")) return { ok: false, reason: `bad nClass '${entry.nClass}'` };
+  if (!Number.isInteger(entry.sts) || entry.sts <= 0) {
+    return { ok: false, reason: `bad sts '${entry.sts}'` };
+  }
+  const aliases = entry.aliases ?? [];
+  if (!Array.isArray(aliases)) return { ok: false, reason: "aliases is not an array" };
+  for (const alias of aliases) {
+    if (!HASH_RE.test(alias)) return { ok: false, reason: `bad alias '${alias}'` };
+    if (alias === hash) return { ok: false, reason: "alias duplicates the primary hash" };
+  }
+  return { ok: true };
+}
+
+function runValidator(hash, harnessDir) {
+  return new Promise((resolve, reject) => {
+    // Absolute: the child's cwd is the harness root, so a relative script path would be resolved
+    // against it a second time.
+    const root = path.resolve(harnessDir);
+    const script = path.join(root, "tests", "validate-player-config.mjs");
+    const child = spawn(process.execPath, [script, hash], {
+      cwd: root,
+      env: childEnv(),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let overflowed = false;
+    const collect = (chunk, into) => {
+      if (into.length + chunk.length > MAX_OUTPUT_BYTES) {
+        overflowed = true;
+        child.kill("SIGKILL");
+        return into;
+      }
+      return into + chunk;
+    };
+    child.stdout.on("data", (c) => (stdout = collect(String(c), stdout)));
+    child.stderr.on("data", (c) => (stderr = collect(String(c), stderr)));
+
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`validator timed out after ${CHILD_TIMEOUT_MS}ms`));
+    }, CHILD_TIMEOUT_MS);
+
+    child.on("error", (e) => {
+      clearTimeout(timer);
+      reject(e);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (overflowed) return reject(new Error("validator output exceeded the byte cap"));
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+function arg(name, fallback = null) {
+  const i = process.argv.indexOf(name);
+  return i > 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+async function main() {
+  const hash = process.argv[2];
+  const harnessDir = arg("--harness", "harness");
+  const outFile = arg("--out");
+  if (!hash || !HASH_RE.test(hash)) {
+    console.error("usage: node tools/propose-config.mjs <hash> --harness <dir> [--out entry.json]");
+    process.exit(1);
+  }
+
+  let run;
+  try {
+    run = await runValidator(hash, harnessDir);
+  } catch (e) {
+    console.log(JSON.stringify({ ok: false, hash, reason: e.message }, null, 2));
+    process.exit(1);
+  }
+
+  // The validator's own exit code is not the verdict — it exits 0 even when nothing validated.
+  // The verdict comes from interpreting what it printed.
+  const verdict = interpretValidatorOutput(hash, run.stdout);
+  const result = {
+    ok: verdict.ok,
+    hash,
+    entry: verdict.entry ?? null,
+    reason: verdict.reason ?? null,
+    workingPairs: verdict.workingPairs ?? [],
+    validatorExit: run.code,
+  };
+
+  process.stderr.write(run.stdout);
+  if (run.stderr) process.stderr.write(run.stderr);
+  console.log(JSON.stringify(result, null, 2));
+
+  if (verdict.ok && outFile) {
+    writeFileSync(outFile, JSON.stringify({ hash, entry: verdict.entry }, null, 2));
+  }
+  process.exit(verdict.ok ? 0 : 1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((e) => {
+    console.log(JSON.stringify({ ok: false, reason: e.message }, null, 2));
+    process.exit(1);
+  });
+}

--- a/tools/tools.test.mjs
+++ b/tools/tools.test.mjs
@@ -1,0 +1,296 @@
+// Regression tests for the pure decision logic behind the automated rotation.
+// No network, no jsdom, no credentials:  node --test tools/tools.test.mjs
+//
+// These cover the gates that stand between "a script found something" and "260,000 devices fetch
+// a new config file": ambiguity refusal, entry shape, environment scrubbing, append-only writing,
+// alias collisions, and what actually counts as a valid CDN response.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { interpretValidatorOutput, validateEntryShape, childEnv } from "./propose-config.mjs";
+import {
+  checkAppendOnly,
+  checkNoCollision,
+  coveredKeys,
+  entryAlreadyCovered,
+  serializeEntry,
+  insertEntryLine,
+} from "./apply-entry.mjs";
+import { cdnResponseIsValid, isGoogleVideoPlaybackUrl } from "./verify-entry.mjs";
+
+const HASH = "b0d2d49a";
+const ENTRY_LINE =
+  `    "${HASH}": { "sig": "EP(3,4223,INPUT)", "nClass": "eg", "sts": 20676, "aliases": ["6fd8f6f9"] }`;
+const WORKS_LINE = "  sig=EP(3,4223,INPUT)     n=g.eg   nProbe.changed=true  GET=206  ✓ WORKS";
+
+const CONFIG_TEXT = [
+  "{",
+  '  "schemaVersion": 1,',
+  '  "players": {',
+  '    "9c249f6f": { "sig": "Tl(48,5831,INPUT)", "nClass": "W_", "sts": 20602, "aliases": ["a6fc27c5"] },',
+  '    "188a8916": { "sig": "hh(26,4464,INPUT)", "nClass": "sV", "sts": 20679, "aliases": ["e945a44c"] }',
+  "  }",
+  "}",
+  "",
+].join("\n");
+
+// ---------------------------------------------------------------- propose (structured verdict)
+
+const RESULT_OK = 'VALIDATOR_RESULT=' + JSON.stringify({
+  ok: true, hash: HASH, workingCount: 1, ambiguous: false,
+  entry: { sig: "EP(3,4223,INPUT)", nClass: "eg", sts: 20676, aliases: ["6fd8f6f9"] },
+});
+
+test("the structured VALIDATOR_RESULT line drives the verdict", () => {
+  // Preferred over any scraped text — even human WORKS lines above it are ignored.
+  const r = interpretValidatorOutput(HASH, [WORKS_LINE, RESULT_OK, ENTRY_LINE].join("\n"));
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.entry, { sig: "EP(3,4223,INPUT)", nClass: "eg", sts: 20676, aliases: ["6fd8f6f9"] });
+});
+
+test("structured ambiguous=true is refused regardless of the human text", () => {
+  const line = 'VALIDATOR_RESULT=' + JSON.stringify({
+    ok: false, hash: HASH, workingCount: 2, ambiguous: true, entry: null,
+  });
+  const r = interpretValidatorOutput(HASH, [WORKS_LINE, line].join("\n"));
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /ambiguous: 2/);
+});
+
+test("structured ok=false / no entry is refused", () => {
+  const line = 'VALIDATOR_RESULT=' + JSON.stringify({ ok: false, hash: HASH, workingCount: 0, ambiguous: false, entry: null });
+  const r = interpretValidatorOutput(HASH, line);
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /no candidate pair returned 206/);
+});
+
+test("structured line with a mismatched hash is refused", () => {
+  const line = 'VALIDATOR_RESULT=' + JSON.stringify({
+    ok: true, hash: "deadbeef", workingCount: 1, ambiguous: false,
+    entry: { sig: "EP(3,4223,INPUT)", nClass: "eg", sts: 20676, aliases: ["6fd8f6f9"] },
+  });
+  const r = interpretValidatorOutput(HASH, line);
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /hash/);
+});
+
+test("structured line whose entry fails the shape check is refused", () => {
+  const line = 'VALIDATOR_RESULT=' + JSON.stringify({
+    ok: true, hash: HASH, workingCount: 1, ambiguous: false,
+    entry: { sig: "alert(1)//(1,2,INPUT)", nClass: "eg", sts: 20676, aliases: [] },
+  });
+  const r = interpretValidatorOutput(HASH, line);
+  assert.equal(r.ok, false);
+});
+
+// ---------------------------------------------------------------- propose (legacy scrape fallback)
+
+test("fallback: a single working pair yields the parsed entry", () => {
+  const r = interpretValidatorOutput(HASH, [WORKS_LINE, "", ENTRY_LINE].join("\n"));
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.entry, { sig: "EP(3,4223,INPUT)", nClass: "eg", sts: 20676, aliases: ["6fd8f6f9"] });
+});
+
+test("fallback: two nChanged=true pairs are refused as ambiguous", () => {
+  const out = [WORKS_LINE, WORKS_LINE.replace("g.eg", "g.zz"), ENTRY_LINE].join("\n");
+  const r = interpretValidatorOutput(HASH, out);
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /ambiguous: 2/);
+  assert.equal(r.workingPairs.length, 2);
+});
+
+test("fallback: a WORKS line with nProbe.changed=false is NOT counted (the #1 over-refusal fix)", () => {
+  // A correct-sig / wrong-n candidate 206s in the 1 MiB free window and prints ✓ WORKS, but with
+  // nProbe.changed=false. It must not inflate the ambiguity count against the one real winner.
+  const wrongN = "  sig=EP(3,4223,INPUT)     n=g.zz   nProbe.changed=false  GET=206  ✓ WORKS";
+  const r = interpretValidatorOutput(HASH, [WORKS_LINE, wrongN, ENTRY_LINE].join("\n"));
+  assert.equal(r.ok, true, "the single nChanged=true pair is the unambiguous winner");
+  assert.deepEqual(r.entry, { sig: "EP(3,4223,INPUT)", nClass: "eg", sts: 20676, aliases: ["6fd8f6f9"] });
+});
+
+test("fallback: no working pair is refused", () => {
+  const r = interpretValidatorOutput(HASH, "  sig=EP(3,4223,INPUT) GET=403\n\n✗ no candidate");
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /no candidate pair returned 206/);
+});
+
+test("fallback: a winner with no printed entry line is refused", () => {
+  const r = interpretValidatorOutput(HASH, WORKS_LINE);
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /printed no entry line/);
+});
+
+test("fallback: an entry line for a different hash is not accepted", () => {
+  const r = interpretValidatorOutput(HASH, [WORKS_LINE, ENTRY_LINE.replace(HASH, "deadbeef")].join("\n"));
+  assert.equal(r.ok, false);
+});
+
+test("entry shape rejects malformed fields", () => {
+  const good = { sig: "EP(3,4223,INPUT)", nClass: "eg", sts: 20676, aliases: ["6fd8f6f9"] };
+  assert.equal(validateEntryShape(HASH, good).ok, true);
+  assert.equal(validateEntryShape(HASH, { ...good, sig: "EP(3,INPUT)" }).ok, false);
+  assert.equal(validateEntryShape(HASH, { ...good, sig: "alert(1)//(1,2,INPUT)" }).ok, false);
+  assert.equal(validateEntryShape(HASH, { ...good, nClass: "a-b" }).ok, false);
+  assert.equal(validateEntryShape(HASH, { ...good, sts: 0 }).ok, false);
+  assert.equal(validateEntryShape(HASH, { ...good, sts: "20676" }).ok, false);
+  assert.equal(validateEntryShape(HASH, { ...good, aliases: ["nothex!!"] }).ok, false);
+  assert.equal(validateEntryShape(HASH, { ...good, aliases: [HASH] }).ok, false, "alias == primary");
+  assert.equal(validateEntryShape("NOTAHASH", good).ok, false);
+});
+
+test("a $ in the n-class is legal", () => {
+  const entry = { sig: "EP(3,4223,INPUT)", nClass: "a$b", sts: 20676, aliases: [] };
+  assert.equal(validateEntryShape(HASH, entry).ok, true);
+});
+
+test("child env forwards only the allowlist", () => {
+  const env = childEnv({
+    PATH: "/usr/bin",
+    HOME: "/home/runner",
+    YT_COOKIE: "SAPISID=x",
+    GITHUB_TOKEN: "ghs_secret",
+    ZEMER_APP_PRIVATE_KEY: "-----BEGIN",
+    AWS_SECRET_ACCESS_KEY: "nope",
+  });
+  assert.deepEqual(Object.keys(env).sort(), ["HOME", "PATH", "YT_COOKIE"]);
+  assert.equal(env.GITHUB_TOKEN, undefined);
+  assert.equal(env.ZEMER_APP_PRIVATE_KEY, undefined);
+});
+
+test("child env drops empty values rather than forwarding blanks", () => {
+  assert.deepEqual(childEnv({ PATH: "/usr/bin", YT_COOKIE: "" }), { PATH: "/usr/bin" });
+});
+
+// ---------------------------------------------------------------- apply
+
+test("covered keys include aliases, not just primaries", () => {
+  const players = JSON.parse(CONFIG_TEXT).players;
+  const keys = coveredKeys(players);
+  assert.ok(keys.has("9c249f6f"));
+  assert.ok(keys.has("a6fc27c5"), "alias counts as covered");
+  assert.equal(keys.size, 4);
+});
+
+test("collision check rejects a hash or alias already covered", () => {
+  const players = JSON.parse(CONFIG_TEXT).players;
+  assert.equal(checkNoCollision(players, "9c249f6f", []).ok, false, "primary collision");
+  assert.equal(checkNoCollision(players, "aaaaaaaa", ["a6fc27c5"]).ok, false, "alias collides");
+  assert.equal(checkNoCollision(players, "a6fc27c5", []).ok, false, "new hash equals an alias");
+  assert.equal(checkNoCollision(players, "aaaaaaaa", ["bbbbbbbb", "bbbbbbbb"]).ok, false, "dup aliases");
+  assert.equal(checkNoCollision(players, "aaaaaaaa", ["bbbbbbbb"]).ok, true);
+});
+
+test("entryAlreadyCovered treats a primary OR alias hit as covered (the #4 noop fix)", () => {
+  const players = JSON.parse(CONFIG_TEXT).players;
+  // Primary already present -> covered (a hand-deploy of the same hash).
+  assert.equal(entryAlreadyCovered(players, "9c249f6f", []), true, "primary present");
+  // The entry's md5 alias is already covered (e.g. the first of two same-md5 skins in one batch
+  // was applied moments ago) -> covered, so the second exits noop(0), never aborting the loop.
+  assert.equal(entryAlreadyCovered(players, "ffffffff", ["a6fc27c5"]), true, "alias already covered");
+  // A genuinely new hash+alias -> not covered (real work to do).
+  assert.equal(entryAlreadyCovered(players, "ffffffff", ["eeeeeeee"]), false, "genuinely new");
+});
+
+test("append-only accepts exactly one addition", () => {
+  const before = JSON.parse(CONFIG_TEXT);
+  const after = JSON.parse(CONFIG_TEXT);
+  after.players.aaaaaaaa = { sig: "EP(3,1,INPUT)", nClass: "eg", sts: 20680 };
+  assert.equal(checkAppendOnly(before, after, "aaaaaaaa").ok, true);
+});
+
+test("append-only rejects removals, edits, extra adds and schema bumps", () => {
+  const before = JSON.parse(CONFIG_TEXT);
+
+  const removed = JSON.parse(CONFIG_TEXT);
+  delete removed.players["9c249f6f"];
+  removed.players.aaaaaaaa = { sig: "EP(3,1,INPUT)", nClass: "eg", sts: 1 };
+  assert.match(checkAppendOnly(before, removed, "aaaaaaaa").reason, /removed/);
+
+  const edited = JSON.parse(CONFIG_TEXT);
+  edited.players["9c249f6f"].sts = 99999;
+  edited.players.aaaaaaaa = { sig: "EP(3,1,INPUT)", nClass: "eg", sts: 1 };
+  assert.match(checkAppendOnly(before, edited, "aaaaaaaa").reason, /was modified/);
+
+  const twoAdds = JSON.parse(CONFIG_TEXT);
+  twoAdds.players.aaaaaaaa = { sig: "EP(3,1,INPUT)", nClass: "eg", sts: 1 };
+  twoAdds.players.bbbbbbbb = { sig: "EP(3,1,INPUT)", nClass: "eg", sts: 1 };
+  assert.match(checkAppendOnly(before, twoAdds, "aaaaaaaa").reason, /exactly 1 new entry/);
+
+  const bumped = JSON.parse(CONFIG_TEXT);
+  bumped.schemaVersion = 2;
+  bumped.players.aaaaaaaa = { sig: "EP(3,1,INPUT)", nClass: "eg", sts: 1 };
+  assert.match(checkAppendOnly(before, bumped, "aaaaaaaa").reason, /schemaVersion changed/);
+});
+
+// ---------------------------------------------------------------- serialization
+
+test("serialized entry matches the committed one-line format", () => {
+  const line = serializeEntry(HASH, {
+    sig: "EP(3,4223,INPUT)",
+    nClass: "eg",
+    sts: 20676,
+    aliases: ["6fd8f6f9"],
+  });
+  assert.equal(line, ENTRY_LINE);
+});
+
+test("an entry with no aliases omits the aliases key", () => {
+  const line = serializeEntry(HASH, { sig: "EP(3,4223,INPUT)", nClass: "eg", sts: 20676, aliases: [] });
+  assert.equal(line, `    "${HASH}": { "sig": "EP(3,4223,INPUT)", "nClass": "eg", "sts": 20676 }`);
+});
+
+test("insertion adds the trailing comma and touches nothing else", () => {
+  const next = insertEntryLine(CONFIG_TEXT, HASH, {
+    sig: "EP(3,4223,INPUT)",
+    nClass: "eg",
+    sts: 20676,
+    aliases: ["6fd8f6f9"],
+  });
+  const parsed = JSON.parse(next);
+  assert.equal(Object.keys(parsed.players).length, 3);
+  assert.deepEqual(parsed.players["9c249f6f"], JSON.parse(CONFIG_TEXT).players["9c249f6f"]);
+
+  const beforeLines = CONFIG_TEXT.split("\n");
+  const afterLines = next.split("\n");
+  // Exactly one line added; the only pre-existing line that may change is the previous last
+  // entry, and only by gaining a comma.
+  assert.equal(afterLines.length, beforeLines.length + 1);
+  assert.equal(afterLines[4], beforeLines[4] + ",");
+  assert.equal(afterLines[5], ENTRY_LINE);
+});
+
+test("insertion refuses a file with no player lines", () => {
+  assert.throws(() => insertEntryLine('{"schemaVersion":1,"players":{}}', HASH, {}), /no existing player lines/);
+});
+
+// ---------------------------------------------------------------- CDN verdict
+
+test("only a real audio 206 off googlevideo counts", () => {
+  const good = {
+    status: 206,
+    contentType: "audio/mp4",
+    contentRange: "bytes 0-262143/5000000",
+    finalUrl: "https://rr3---sn-abc.googlevideo.com/videoplayback?x=1",
+    bytesRead: 4096,
+  };
+  assert.equal(cdnResponseIsValid(good), true);
+  assert.equal(cdnResponseIsValid({ ...good, status: 200 }), false, "200 is not a range response");
+  assert.equal(cdnResponseIsValid({ ...good, status: 403 }), false);
+  assert.equal(cdnResponseIsValid({ ...good, contentType: "text/html" }), false, "an error page");
+  assert.equal(cdnResponseIsValid({ ...good, contentRange: null }), false);
+  assert.equal(cdnResponseIsValid({ ...good, bytesRead: 0 }), false, "headers only, no bytes");
+  assert.equal(
+    cdnResponseIsValid({ ...good, finalUrl: "https://example.com/videoplayback" }),
+    false,
+    "redirected off the CDN",
+  );
+});
+
+test("googlevideo URL check is host- and path-exact", () => {
+  assert.equal(isGoogleVideoPlaybackUrl("https://r1---sn-x.googlevideo.com/videoplayback?a=1"), true);
+  assert.equal(isGoogleVideoPlaybackUrl("http://r1---sn-x.googlevideo.com/videoplayback"), false, "http");
+  assert.equal(isGoogleVideoPlaybackUrl("https://googlevideo.com.evil.tld/videoplayback"), false);
+  assert.equal(isGoogleVideoPlaybackUrl("https://r1---sn-x.googlevideo.com/other"), false);
+  assert.equal(isGoogleVideoPlaybackUrl("not a url"), false);
+});

--- a/tools/verify-entry.mjs
+++ b/tools/verify-entry.mjs
@@ -1,0 +1,354 @@
+// Independently verify a proposed player_configs.json entry against the live CDN.
+//
+// This is deliberately a SECOND implementation of the check, written here in the cipher repo,
+// separate from the zemer-app harness validator that proposed the entry. Nothing reaches master
+// unless two independently-written code paths both get HTTP 206 out of it. It is also stricter
+// than the proposer in three ways that matter when no human is watching:
+//
+//   * MULTI-SIGNATURE. The proposer validates ONE signature. A single sample can pass by luck
+//     (e.g. a format whose `n` happens to round-trip). We require >= MIN_SIGNATURES *distinct*
+//     `s` values to decipher and fetch, drawn from the ciphered audio formats of the response —
+//     the same fluke guard faraday gets from two videos, without needing a second video to be
+//     reachable (most ids are bot-gated from datacenter IPs).
+//   * REAL BYTES. 206 alone is not proof. We require content-type audio/*, a well-formed
+//     content-range, a final URL still on googlevideo /videoplayback (no redirect off-CDN), and
+//     we actually drain MIN_STREAM_BYTES off the socket.
+//   * SELF-CONSISTENCY. The entry's `sts` must equal the signatureTimestamp base.js declares,
+//     and its md5 alias must equal the md5 of the first 10000 bytes — the identity devices key on.
+//
+// The n-transform template is imported from the harness rather than re-typed: it is pinned
+// byte-for-byte against the Kotlin PlayerConfigParser by shared parity fixtures, and a third
+// hand-written copy is exactly how those drift apart.
+//
+//   node tools/verify-entry.mjs --entry entry.json --harness <dir> [--videos a,b]
+//
+// stdout: JSON verdict. exit 0 only on a full pass.
+
+import crypto from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+// jsdom is imported lazily inside buildCipher so the pure predicates below stay importable
+// (and unit-testable) without the dependency installed.
+
+const ORIGIN = "https://music.youtube.com";
+const WEB_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0";
+const WEB_REMIX = { clientName: "WEB_REMIX", clientVersion: "1.20260213.01.00", clientId: "67" };
+
+const MIN_SIGNATURES = 2;
+const MIN_STREAM_BYTES = 1024;
+const RANGE = "bytes=0-262143";
+const FETCH_TIMEOUT_MS = 20_000;
+const N_PROBE_INPUT = "KdrqFlzJXl9EcCwlmEy";
+const VALID_N_RESULT = /^[a-zA-Z0-9_-]+$/;
+
+const md5hash4 = (s) =>
+  crypto.createHash("md5").update(Buffer.from(s.slice(0, 10000), "utf8")).digest("hex").slice(0, 8);
+
+const decodeVisitor = (v) => {
+  try {
+    return v && /%[0-9A-Fa-f]{2}/.test(v) ? decodeURIComponent(v) : v;
+  } catch {
+    return v;
+  }
+};
+
+function sapisidHash(cookie) {
+  const m = cookie.match(/(?:^|; )SAPISID=([^;]+)/);
+  if (!m) return null;
+  const ts = Math.floor(Date.now() / 1000);
+  return `SAPISIDHASH ${ts}_${crypto
+    .createHash("sha1")
+    .update(`${ts} ${m[1]} ${ORIGIN}`)
+    .digest("hex")}`;
+}
+
+async function withTimeout(fn, ms = FETCH_TIMEOUT_MS) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ms);
+  try {
+    return await fn(controller.signal);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchPlayerJs(hash) {
+  const url = `https://www.youtube.com/s/player/${hash}/player_ias.vflset/en_GB/base.js`;
+  const r = await withTimeout((signal) => fetch(url, { headers: { "User-Agent": WEB_UA }, signal }));
+  if (!r.ok) throw new Error(`base.js HTTP ${r.status}`);
+  return r.text();
+}
+
+/** Ciphered audio formats for one video, deduped by their `s` value. */
+async function signatureCiphersFor(sts, videoId, cred) {
+  const headers = {
+    "Content-Type": "application/json",
+    "User-Agent": WEB_UA,
+    "X-Goog-Api-Format-Version": "1",
+    "X-YouTube-Client-Name": WEB_REMIX.clientId,
+    "X-YouTube-Client-Version": WEB_REMIX.clientVersion,
+    "X-Origin": ORIGIN,
+    Referer: `${ORIGIN}/`,
+  };
+  if (cred.visitorData) headers["X-Goog-Visitor-Id"] = cred.visitorData;
+  if (cred.cookie) {
+    headers.cookie = cred.cookie;
+    const auth = sapisidHash(cred.cookie);
+    if (auth) headers.Authorization = auth;
+  }
+  const client = { clientName: WEB_REMIX.clientName, clientVersion: WEB_REMIX.clientVersion, gl: "US", hl: "en" };
+  if (cred.visitorData) client.visitorData = cred.visitorData;
+
+  const r = await withTimeout((signal) =>
+    fetch(`${ORIGIN}/youtubei/v1/player?prettyPrint=false`, {
+      method: "POST",
+      headers,
+      signal,
+      body: JSON.stringify({
+        context: { client },
+        videoId,
+        playbackContext: { contentPlaybackContext: { signatureTimestamp: sts } },
+      }),
+    }),
+  );
+  const json = JSON.parse(await r.text());
+  const playability = json?.playabilityStatus?.status ?? null;
+  const seen = new Map();
+  for (const f of json?.streamingData?.adaptiveFormats ?? []) {
+    if (!f.signatureCipher || !(f.mimeType || "").startsWith("audio/")) continue;
+    const s = new URLSearchParams(f.signatureCipher).get("s");
+    if (s && !seen.has(s)) seen.set(s, f.signatureCipher);
+  }
+  return { videoId, playability, ciphers: [...seen.values()] };
+}
+
+/** Evaluate base.js in jsdom with the entry's sig expression + n class. */
+async function buildCipher(playerJs, sigExpr, nClass, nTrick) {
+  const { JSDOM } = await import("jsdom");
+  const nExpr = nTrick(nClass);
+  const sigStmt = `window._cipherSigFunc = function(sig){ try { return ${sigExpr.replace(
+    "INPUT",
+    "sig",
+  )}; } catch(e){ return null; } };`;
+  const nStmt = `window._nTransformFunc = function(n){ try { return ${nExpr.replace(
+    "INPUT",
+    "n",
+  )}; } catch(e){ return n; } };`;
+  const exportCode = `; ${sigStmt} ${nStmt} `;
+  let modified = playerJs.replace("})(_yt_player);", `${exportCode}})(_yt_player);`);
+  if (modified === playerJs) modified = `${playerJs}\n${exportCode}`;
+
+  const dom = new JSDOM("<!DOCTYPE html><html><head></head><body></body></html>", {
+    url: "https://www.youtube.com/",
+    pretendToBeVisual: true,
+    runScripts: "outside-only",
+  });
+  const win = dom.window;
+  win._yt_player = {};
+  if (!win.TextEncoder) win.TextEncoder = TextEncoder;
+  if (!win.TextDecoder) win.TextDecoder = TextDecoder;
+  let initError = null;
+  try {
+    win.eval(modified);
+  } catch (e) {
+    initError = e.message;
+  }
+  const sigFn = win._cipherSigFunc;
+  const nFn = win._nTransformFunc;
+
+  let nProbe = { changed: false, valid: false };
+  try {
+    const out = nFn(N_PROBE_INPUT);
+    nProbe = {
+      changed: !!out && out !== N_PROBE_INPUT,
+      valid: !!out && out !== N_PROBE_INPUT && VALID_N_RESULT.test(String(out)),
+    };
+  } catch (e) {
+    nProbe = { changed: false, valid: false, error: e.message };
+  }
+
+  return {
+    initError,
+    nProbe,
+    deobfuscate(signatureCipher) {
+      const p = {};
+      for (const pair of signatureCipher.split("&")) {
+        const i = pair.indexOf("=");
+        if (i > 0) p[decodeURIComponent(pair.slice(0, i))] = decodeURIComponent(pair.slice(i + 1));
+      }
+      if (p.s == null || p.url == null) throw new Error("signatureCipher missing s/url");
+      const sig = sigFn(p.s);
+      if (sig == null) throw new Error("sig function returned null");
+      let out = `${p.url}${p.url.includes("?") ? "&" : "?"}${p.sp || "signature"}=${encodeURIComponent(
+        String(sig),
+      )}`;
+      const m = out.match(/[?&]n=([^&]+)/);
+      if (m) {
+        const t = nFn(decodeURIComponent(m[1]));
+        out = out.replace(/([?&])n=[^&]+/, `$1n=${encodeURIComponent(t == null ? m[1] : String(t))}`);
+      }
+      return out;
+    },
+    close: () => win.close(),
+  };
+}
+
+/** A 206 that is actually a playable audio range, not just a status code. */
+export function cdnResponseIsValid({ status, contentType, contentRange, finalUrl, bytesRead }) {
+  if (status !== 206) return false;
+  if (!(contentType || "").toLowerCase().startsWith("audio/")) return false;
+  if (!contentRange || !/^bytes 0-\d+\/(?:\d+|\*)$/i.test(contentRange)) return false;
+  if (!isGoogleVideoPlaybackUrl(finalUrl)) return false;
+  return bytesRead >= MIN_STREAM_BYTES;
+}
+
+export function isGoogleVideoPlaybackUrl(value) {
+  try {
+    const u = new URL(value);
+    return (
+      u.protocol === "https:" && u.hostname.endsWith(".googlevideo.com") && u.pathname === "/videoplayback"
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function probeCdn(url) {
+  if (!isGoogleVideoPlaybackUrl(url)) {
+    return { status: "ERR:not-a-googlevideo-url", valid: false, bytesRead: 0 };
+  }
+  try {
+    const r = await withTimeout((signal) =>
+      fetch(url, { headers: { "User-Agent": WEB_UA, Range: RANGE, Connection: "close" }, signal }),
+    );
+    const contentType = r.headers.get("content-type");
+    const contentRange = r.headers.get("content-range");
+    let bytesRead = 0;
+    if (r.body) {
+      const reader = r.body.getReader();
+      while (bytesRead < MIN_STREAM_BYTES) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        bytesRead += value?.byteLength ?? 0;
+      }
+      await reader.cancel();
+    }
+    const info = { status: r.status, contentType, contentRange, finalUrl: r.url, bytesRead };
+    return { ...info, valid: cdnResponseIsValid(info) };
+  } catch (e) {
+    return { status: `ERR:${e.message.slice(0, 40)}`, valid: false, bytesRead: 0 };
+  }
+}
+
+function arg(name, fallback = null) {
+  const i = process.argv.indexOf(name);
+  return i > 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+async function main() {
+  const entryFile = arg("--entry");
+  const harnessDir = arg("--harness", "harness");
+  // We need MIN_SIGNATURES (>=2) DISTINCT signatures; the loop walks this list until it has enough.
+  // Default to MORE THAN ONE video so a response that happens to carry <2 ciphered audio formats
+  // (only itag 140 ciphered, the rest plain-url/SABR) doesn't reject an otherwise-valid entry —
+  // it falls through to the next id. dQw4w9WgXcQ leads because from a datacenter IP almost every
+  // other id is bot-gated in guest mode (measured 1 of 10), and it reliably returns 4 ciphered
+  // audio formats; the extra ids are the fallback for the rare short response. Override with
+  // --videos or the VALIDATION_VIDEO_IDS repo var (with a cookie, any id works).
+  const videos = (arg("--videos", process.env.VALIDATION_VIDEO_IDS || "dQw4w9WgXcQ,84mNcwGCIUE,kJQP7kiw5Fk") || "")
+    .split(",")
+    .map((v) => v.trim())
+    .filter(Boolean);
+  if (!entryFile) {
+    console.error("usage: node tools/verify-entry.mjs --entry entry.json --harness <dir> [--videos a,b]");
+    process.exit(1);
+  }
+
+  const { hash, entry } = JSON.parse(readFileSync(entryFile, "utf8"));
+  // One JS copy of the n-IIFE template, shared with the harness and pinned to the Kotlin parser.
+  const { nTrick } = await import(
+    pathToFileURL(path.resolve(harnessDir, "tests", "player-configs.mjs")).href
+  );
+
+  const cred = {
+    cookie: process.env.YT_COOKIE || "",
+    visitorData: decodeVisitor(process.env.YT_VISITOR_DATA || ""),
+  };
+
+  const js = await fetchPlayerJs(hash);
+  const declaredSts = Number((js.match(/signatureTimestamp[':\s"]+(\d{4,6})/) || [])[1]);
+  const md5 = md5hash4(js);
+
+  const checks = [];
+  const fail = (name, detail) => checks.push({ name, ok: false, detail });
+  const pass = (name, detail) => checks.push({ name, ok: true, detail });
+
+  if (entry.sts !== declaredSts) {
+    fail("sts-matches-base.js", `entry ${entry.sts} != base.js ${declaredSts}`);
+  } else pass("sts-matches-base.js", String(declaredSts));
+
+  const aliases = entry.aliases ?? [];
+  if (md5 !== hash && !aliases.includes(md5)) {
+    fail("md5-alias-present", `md5 ${md5} missing from aliases ${JSON.stringify(aliases)}`);
+  } else pass("md5-alias-present", md5);
+
+  // Gather distinct signatures, walking the video list until we have enough. Most ids are
+  // bot-gated from datacenter IPs, so a failure here is "try the next id", not a verdict.
+  const ciphers = [];
+  const videoReport = [];
+  for (const videoId of videos) {
+    if (ciphers.length >= MIN_SIGNATURES) break;
+    try {
+      const r = await signatureCiphersFor(declaredSts, videoId, cred);
+      videoReport.push({ videoId, playability: r.playability, ciphers: r.ciphers.length });
+      ciphers.push(...r.ciphers);
+    } catch (e) {
+      videoReport.push({ videoId, error: e.message.slice(0, 60) });
+    }
+  }
+  const distinct = [...new Set(ciphers)].slice(0, MIN_SIGNATURES);
+  if (distinct.length < MIN_SIGNATURES) {
+    fail("distinct-signatures", `got ${distinct.length}, need ${MIN_SIGNATURES}`);
+    return report(false, { hash, entry, checks, videoReport, probes: [] });
+  }
+  pass("distinct-signatures", String(distinct.length));
+
+  const cipher = await buildCipher(js, entry.sig, entry.nClass, nTrick);
+  if (!cipher.nProbe.valid) {
+    fail("n-transform-produces-valid-output", JSON.stringify(cipher.nProbe));
+  } else pass("n-transform-produces-valid-output", "ok");
+
+  const probes = [];
+  for (const signatureCipher of distinct) {
+    try {
+      const url = cipher.deobfuscate(signatureCipher);
+      probes.push(await probeCdn(url));
+    } catch (e) {
+      probes.push({ status: `deob-fail:${e.message.slice(0, 50)}`, valid: false, bytesRead: 0 });
+    }
+  }
+  cipher.close();
+
+  const allValid = probes.length === MIN_SIGNATURES && probes.every((p) => p.valid);
+  if (!allValid) fail("all-signatures-return-206-with-bytes", JSON.stringify(probes.map((p) => p.status)));
+  else pass("all-signatures-return-206-with-bytes", probes.map((p) => `${p.status}/${p.bytesRead}B`).join(" "));
+
+  return report(
+    checks.every((c) => c.ok),
+    { hash, entry, checks, videoReport, probes },
+  );
+}
+
+function report(ok, payload) {
+  console.log(JSON.stringify({ ok, ...payload }, null, 2));
+  process.exit(ok ? 0 : 1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((e) => {
+    console.log(JSON.stringify({ ok: false, reason: e.message }, null, 2));
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Adds the player-config rotation automation on top of master, with none of the burn-in's generated config commits. `player_configs.json` and `player_dates.json` are byte-identical to master.

### Included
- `.github/workflows/player-monitor.yml`: hourly monitor plus derive/validate/deploy/verify pipeline
- `tools/`: `propose-config`, `verify-entry`, `apply-entry`, and unit tests

### Safety properties
- Fail-closed: a hash reaches a commit only after two independent live 206 checks (`propose-config` then `verify-entry`), followed by a parser-parity gate before push.
- Untrusted player JS is evaluated only in an isolated permission-less job that holds no write credential.
- Post-push verify reads the deployed file back over git protocol and reverts only a proven-bad deploy.

### Deploy stays off
The pipeline is inert until the `AUTO_DEPLOY_CONFIG` repo variable is set. Merging this does not enable auto-deploy; that stays a separate deliberate step.
